### PR TITLE
Enable passing 'propagate' keyword argument to log_capture() decorator

### DIFF
--- a/testfixtures/logcapture.py
+++ b/testfixtures/logcapture.py
@@ -158,6 +158,8 @@ def log_capture(*names, **kw):
                   will be captured.
     """
     level = kw.pop('level',1)
-    l = LogCaptureForDecorator(names or None, install=False, level=level)
+    propagate = kw.pop('propagate', None)
+    l = LogCaptureForDecorator(names or None, install=False, level=level,
+                               propagate=propagate)
     return wrap(l.install,l.uninstall)
 

--- a/testfixtures/tests/test_log_capture.py
+++ b/testfixtures/tests/test_log_capture.py
@@ -118,3 +118,19 @@ class TestLog_Capture(TestCase):
         capture.uninstall()
         self.assertFalse(capture in _handlers)
         self.assertFalse(capture in _handlerList)
+
+    def test_no_propogate(self):
+        logger = getLogger('child')
+        # paranoid check
+        compare(logger.propagate, True)
+
+        @log_capture('child', propagate=False)
+        def test_method(l):
+            logger.info('a log message')
+            l.check(('child', 'INFO', 'a log message'))
+
+        with LogCapture() as global_log:
+            test_method()
+
+        global_log.check()
+        compare(logger.propagate, True)


### PR DESCRIPTION
The log_capture() decorator is meant to be a wrapper for LogCapture so it should support all the same keyword arguments.
