### PR TITLE
Use explicit expected/actual for internal calls to compare()

### DIFF
--- a/docs/files.txt
+++ b/docs/files.txt
@@ -342,10 +342,10 @@ AssertionError: sequence not as expected:
 same:
 ()
 <BLANKLINE>
-first:
+expected:
 ('subdir',)
 <BLANKLINE>
-second:
+actual:
 ('root.txt', 'subdir')
 
 In some circumstances, you may want to ignore certain files or

--- a/docs/logging.txt
+++ b/docs/logging.txt
@@ -50,10 +50,10 @@ AssertionError: sequence not as expected:
 same:
 (('root', 'INFO', 'a message'),)
 <BLANKLINE>
-first:
+expected:
 (('root', 'ERROR', 'another error'),)
 <BLANKLINE>
-second:
+actual:
 (('root', 'ERROR', 'an error'),)
 
 It also has a string representation that allows you to see what has
@@ -189,10 +189,10 @@ AssertionError: sequence not as expected:
 same:
 (('root', 'INFO', 'start of block number 1'),)
 <BLANKLINE>
-first:
+expected:
 ()
 <BLANKLINE>
-second:
+actual:
 (('root', 'ERROR', 'error occurred'),)
 
 Printing

--- a/docs/streams.txt
+++ b/docs/streams.txt
@@ -37,7 +37,7 @@ of leading and trailing whitespace before the comparison is done:
 ...    o.compare(' Foo!  ')
 Traceback (most recent call last):
 ...
-AssertionError: 'Foo!' != 'Bar!'
+AssertionError: 'Foo!' (expected) != 'Bar!' (actual)
 
 However, if you need to make very explicit assertions about what has
 been written to the stream then you can do so using the `captured`

--- a/testfixtures/logcapture.py
+++ b/testfixtures/logcapture.py
@@ -128,7 +128,7 @@ class LogCapture(logging.Handler):
         """
         return compare(
             expected,
-            tuple(self.actual()),
+            actual=tuple(self.actual()),
             recursive=False
             )
 

--- a/testfixtures/outputcapture.py
+++ b/testfixtures/outputcapture.py
@@ -74,5 +74,5 @@ class OutputCapture(object):
                 ('stdout', stdout, self.stdout.getvalue()),
                 ('stderr', stderr, self.stderr.getvalue()),
         ):
-            compare(_expected.strip(), captured.strip(), prefix=prefix)
+            compare(_expected.strip(), actual=captured.strip(), prefix=prefix)
 

--- a/testfixtures/tempdirectory.py
+++ b/testfixtures/tempdirectory.py
@@ -176,7 +176,7 @@ class TempDirectory:
                           in the actual contents used for comparison.
         """
         compare(expected,
-                tuple(self.actual(path, recursive, files_only)),
+                actual=tuple(self.actual(path, recursive, files_only)),
                 recursive=False)
 
     def check(self, *expected):

--- a/testfixtures/tests/test_tempdir.py
+++ b/testfixtures/tests/test_tempdir.py
@@ -38,7 +38,7 @@ class TestTempDir(TestCase):
         d.write('something', b'stuff')
 
         with ShouldRaise(AssertionError(
-            "sequence not as expected:\n\nsame:\n()\n\nfirst:\n('.svn', 'something')\n\nsecond:\n('something',)"
+            "sequence not as expected:\n\nsame:\n()\n\nexpected:\n('.svn', 'something')\n\nactual:\n('something',)"
             )):
 
             d.compare(['.svn', 'something'])


### PR DESCRIPTION
Use explicit expected/actual for internal calls to `compare()` in:
* `LogCapture.check()`
* `OutputCapture.compare()`
* `TempDirectory.compare()`

Fixes #26 