### PR TITLE
cStringIO cannot handle some Unicode strings.

### DIFF
--- a/testfixtures/compat.py
+++ b/testfixtures/compat.py
@@ -36,7 +36,7 @@ else:
     exception_module = 'exceptions'
     from new import classobj as new_class
     self_name = 'im_self'
-    from cStringIO import StringIO
+    from StringIO import StringIO
     xrange = xrange
 
 try:

--- a/testfixtures/tests/test_outputcapture.py
+++ b/testfixtures/tests/test_outputcapture.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from __future__ import print_function
 # Copyright (c) 2010-2011 Simplistix Ltd
 # Copyright (c) 2015 Chris Withers
@@ -23,6 +25,12 @@ class TestOutputCapture(TestCase):
             print('there', file=sys.stdout)
             print('now', file=sys.stderr)
         o.compare("hello\nout\nthere\nnow\n")
+
+    def test_unicode(self):
+        with OutputCapture() as o:
+            print(u'こんにちわ', file=sys.stdout)
+            print(u'アウト', file=sys.stderr)
+        o.compare(u"こんにちわ\nアウト\n")
 
     def test_separate_capture(self):
         with OutputCapture(separate=True) as o:

--- a/testfixtures/tests/test_outputcapture.py
+++ b/testfixtures/tests/test_outputcapture.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import print_function
 # Copyright (c) 2010-2011 Simplistix Ltd
 # Copyright (c) 2015 Chris Withers
@@ -28,9 +26,8 @@ class TestOutputCapture(TestCase):
 
     def test_unicode(self):
         with OutputCapture() as o:
-            print(u'こんにちわ', file=sys.stdout)
-            print(u'アウト', file=sys.stderr)
-        o.compare(u"こんにちわ\nアウト\n")
+            print(u'\u65e5', file=sys.stdout)
+        o.compare(u'\u65e5\n')
 
     def test_separate_capture(self):
         with OutputCapture(separate=True) as o:


### PR DESCRIPTION
@cjw296 

First, thanks for the awesome tool.
I encountered errors such as the following.

```
# -*- coding: utf-8 -*-
from testfixtures import OutputCapture

with OutputCapture() as output:
    print(u"こんにちわ")
```
error
```
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-4: ordinal not in range(128)
```

The cause of this error is because cStringIO cannot handle some Unicode strings well.
see also https://docs.python.org/2.7/library/stringio.html?highlight=cstringio#module-cStringIO

I have changed cStringIO to StringIO. Please feel free to merge it.