### PR TITLE
Add builds on Python nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ python:
   - "2.7"
   - "nightly"
 
+matrix:
+  allow_failures:
+    - python: "nightly"
+
 # command to install dependencies
 install: "pip install -Ue .[test,build]"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
   - "3.4"
   - "3.3"
   - "2.7"
+  - "nightly"
 
 # command to install dependencies
 install: "pip install -Ue .[test,build]"


### PR DESCRIPTION
Some import errors on current Python nightly (3.6.0a0).

Might be better to allow failures in this env, but maybe worth trying without.