### PR TITLE
Fix: running tests with PyPy v4.0.1 breaks the build with TypeError

### DIFF
--- a/testfixtures/replace.py
+++ b/testfixtures/replace.py
@@ -139,5 +139,5 @@ replace_params_doc = """
 for obj in (Replacer.__call__, Replacer.replace, replace, Replace):
     try:
         obj.__doc__ += replace_params_doc
-    except AttributeError: # python 2 :-(
+    except (AttributeError, TypeError): # python 2 or pypy 4.0.1 :-(
         pass


### PR DESCRIPTION
Since testfixtures v4.8, PyPy v4.0.1 would break with `TypeError` instead of `AttributeError` (see [this](https://travis-ci.org/nicolaiarocci/eve/jobs/111175613) Travis build). According to [this](https://bitbucket.org/pypy/pypy/issues/1108/cpyext-typeerror-instead-of-attributeerror) comment by Armin Rigo, PyPy will sometimes raise TypeError whereas CPython raises `AttributeError`.

This patch allows PyPy v4.0.1 (Python 2.7.10) to run the tests without issues.