### PR TITLE
Clarify behaviour of TempDirectory.compare()

### DIFF
--- a/testfixtures/tempdirectory.py
+++ b/testfixtures/tempdirectory.py
@@ -158,12 +158,15 @@ class TempDirectory:
                 followlinks=False):
         """
         Compare the expected contents with the actual contents of the temporary
-        directory.
+        directory. An :class:`AssertionError` will be raised if they are not the
+        same.
 
         :param expected: A sequence of strings containing the paths
                          expected in the directory. These paths should
                          be forward-slash separated and relative to
-                         the root of the temporary directory.
+                         the root of the temporary directory. The sequence
+                         should be sorted, otherwise the comparison will
+                         fail (even if the paths are the same).
 
         :param path: The path to use as the root for the comparison,
                      relative to the root of the temporary directory.


### PR DESCRIPTION
Thanks a lot for making `testfixtures` available! :)

This PR adds a couple of comments clarifying the behaviour of `TempDirectory.compare()`. I'm not sure if it's intended behaviour that the comparison fails if the argument `expected` is not sorted but at least it's good to document this.
