### PR TITLE
better status images for github landing page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,9 @@
 |Travis|_ |Coveralls|_ |Docs|_
 
-.. |Travis| image:: https://api.travis-ci.org/Simplistix/testfixtures.png?branch=master
+.. |Travis| image:: https://api.travis-ci.org/Simplistix/testfixtures.svg?branch=master
 .. _Travis: https://travis-ci.org/Simplistix/testfixtures
 
-.. |Coveralls| image:: https://coveralls.io/repos/Simplistix/testfixtures/badge.png?branch=master
+.. |Coveralls| image:: https://coveralls.io/repos/Simplistix/testfixtures/badge.svg?branch=master
 .. _Coveralls: https://coveralls.io/r/Simplistix/testfixtures?branch=master
 
 .. |Docs| image:: https://readthedocs.org/projects/testfixtures/badge/?version=latest


### PR DESCRIPTION
just a minor annoyance with coveralls badge.  here's a before/after .gif for this change:

![out](https://cloud.githubusercontent.com/assets/6615374/20407549/6dda779c-acd7-11e6-81f8-8bb6a0556189.gif)
