### PR TITLE
Implement Popen stderr to stdout redirection

### DIFF
--- a/testfixtures/popen.py
+++ b/testfixtures/popen.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2015 Simplistix Ltd
 # See license.txt for license details.
 from mock import Mock
-from subprocess import Popen as Popen
+from subprocess import Popen as Popen, STDOUT
 from tempfile import TemporaryFile
 from testfixtures.compat import basestring
 from testfixtures.utils import extend_docstring
@@ -69,6 +69,11 @@ class MockPopen(object):
 
         self.stdout, self.stderr, self.returncode, pid, poll = behaviour
         self.poll_count = poll
+
+        if stderr == STDOUT:
+            self.stdout += self.stderr
+            self.stderr = b''
+
         for name in 'stdout', 'stderr':
             f = TemporaryFile()
             f.write(getattr(self, name))

--- a/testfixtures/popen.py
+++ b/testfixtures/popen.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2015 Simplistix Ltd
 # See license.txt for license details.
+from itertools import chain, izip_longest
 from mock import Mock
 from subprocess import Popen as Popen, STDOUT
 from tempfile import TemporaryFile
@@ -71,7 +72,11 @@ class MockPopen(object):
         self.poll_count = poll
 
         if stderr == STDOUT:
-            self.stdout += self.stderr
+            line_iterator = chain.from_iterable(izip_longest(
+                self.stdout.splitlines(True),
+                self.stderr.splitlines(True)
+            ))
+            self.stdout = b''.join(l for l in line_iterator if l)
             self.stderr = None
 
         for name in 'stdout', 'stderr':

--- a/testfixtures/popen.py
+++ b/testfixtures/popen.py
@@ -72,11 +72,14 @@ class MockPopen(object):
 
         if stderr == STDOUT:
             self.stdout += self.stderr
-            self.stderr = b''
+            self.stderr = None
 
         for name in 'stdout', 'stderr':
+            value = getattr(self, name)
+            if value is None:
+                continue
             f = TemporaryFile()
-            f.write(getattr(self, name))
+            f.write(value)
             f.flush()
             f.seek(0)
             setattr(self.mock.Popen_instance, name, f)

--- a/testfixtures/tests/test_popen.py
+++ b/testfixtures/tests/test_popen.py
@@ -116,6 +116,17 @@ class Tests(TestCase):
         # test stdout contents
         compare(b'foobar', process.stdout.read())
 
+    def test_read_from_stdout_with_stderr_redirected_check_stdout_stderr_interleaved(self):
+        # setup
+        Popen = MockPopen()
+        Popen.set_command('a command', stdout=b'o1\no2\no3\no4\n', stderr=b'e1\ne2\n')
+        # usage
+        process = Popen('a command', stdout=PIPE, stderr=STDOUT, shell=True)
+        self.assertTrue(isinstance(process.stdout.fileno(), int))
+        # test stdout contents
+        compare(b'o1\ne1\no2\ne2\no3\no4\n', process.stdout.read())
+
+
     def test_communicate_with_stderr_redirected_check_stderr_is_none(self):
         # setup
         Popen = MockPopen()

--- a/testfixtures/tests/test_popen.py
+++ b/testfixtures/tests/test_popen.py
@@ -106,7 +106,7 @@ class Tests(TestCase):
                 call.Popen('a command', shell=True, stderr=-1, stdout=-1),
                 ], Popen.mock.method_calls)
 
-    def test_read_from_stdout_with_stderr_redirected_check_stderr_in_stdout(self):
+    def test_read_from_stdout_with_stderr_redirected_check_stdout_contents(self):
         # setup
         Popen = MockPopen()
         Popen.set_command('a command', stdout=b'foo', stderr=b'bar')
@@ -114,17 +114,7 @@ class Tests(TestCase):
         process = Popen('a command', stdout=PIPE, stderr=STDOUT, shell=True)
         self.assertTrue(isinstance(process.stdout.fileno(), int))
         # test stdout contents
-        self.assertIn(b'bar', process.stdout.read())
-
-    def test_read_from_stdout_with_stderr_redirected_check_stdout_in_stdout(self):
-        # setup
-        Popen = MockPopen()
-        Popen.set_command('a command', stdout=b'foo', stderr=b'bar')
-        # usage
-        process = Popen('a command', stdout=PIPE, stderr=STDOUT, shell=True)
-        self.assertTrue(isinstance(process.stdout.fileno(), int))
-        # test stdout contents
-        self.assertIn(b'foo', process.stdout.read())
+        compare(b'foobar', process.stdout.read())
 
     def test_communicate_with_stderr_redirected_check_stderr_is_none(self):
         # setup

--- a/testfixtures/tests/test_popen.py
+++ b/testfixtures/tests/test_popen.py
@@ -1,4 +1,4 @@
-from subprocess import PIPE
+from subprocess import PIPE, STDOUT
 from unittest import TestCase
 
 from mock import call
@@ -105,6 +105,26 @@ class Tests(TestCase):
         compare([
                 call.Popen('a command', shell=True, stderr=-1, stdout=-1),
                 ], Popen.mock.method_calls)
+
+    def test_read_from_stdout_with_stderr_redirected_check_stderr_in_stdout(self):
+        # setup
+        Popen = MockPopen()
+        Popen.set_command('a command', stdout=b'foo', stderr=b'bar')
+        # usage
+        process = Popen('a command', stdout=PIPE, stderr=STDOUT, shell=True)
+        self.assertTrue(isinstance(process.stdout.fileno(), int))
+        # test stdout contents
+        self.assertIn('bar', process.stdout.read())
+
+    def test_read_from_stdout_with_stderr_redirected_check_stdout_in_stdout(self):
+        # setup
+        Popen = MockPopen()
+        Popen.set_command('a command', stdout=b'foo', stderr=b'bar')
+        # usage
+        process = Popen('a command', stdout=PIPE, stderr=STDOUT, shell=True)
+        self.assertTrue(isinstance(process.stdout.fileno(), int))
+        # test stdout contents
+        self.assertIn('foo', process.stdout.read())
 
     def test_read_from_stdout_and_stderr(self):
         # setup

--- a/testfixtures/tests/test_popen.py
+++ b/testfixtures/tests/test_popen.py
@@ -114,7 +114,7 @@ class Tests(TestCase):
         process = Popen('a command', stdout=PIPE, stderr=STDOUT, shell=True)
         self.assertTrue(isinstance(process.stdout.fileno(), int))
         # test stdout contents
-        self.assertIn('bar', process.stdout.read())
+        self.assertIn(b'bar', process.stdout.read())
 
     def test_read_from_stdout_with_stderr_redirected_check_stdout_in_stdout(self):
         # setup
@@ -124,7 +124,7 @@ class Tests(TestCase):
         process = Popen('a command', stdout=PIPE, stderr=STDOUT, shell=True)
         self.assertTrue(isinstance(process.stdout.fileno(), int))
         # test stdout contents
-        self.assertIn('foo', process.stdout.read())
+        self.assertIn(b'foo', process.stdout.read())
 
     def test_read_from_stdout_and_stderr(self):
         # setup

--- a/testfixtures/tests/test_popen.py
+++ b/testfixtures/tests/test_popen.py
@@ -126,6 +126,16 @@ class Tests(TestCase):
         # test stdout contents
         self.assertIn(b'foo', process.stdout.read())
 
+    def test_communicate_with_stderr_redirected_check_stderr_is_none(self):
+        # setup
+        Popen = MockPopen()
+        Popen.set_command('a command', stdout=b'foo', stderr=b'bar')
+        # usage
+        process = Popen('a command', stdout=PIPE, stderr=STDOUT, shell=True)
+        out, err = process.communicate()
+        # test stderr is None
+        compare(err, None)
+
     def test_read_from_stdout_and_stderr(self):
         # setup
         Popen = MockPopen()


### PR DESCRIPTION
Currently, if a call to Popen uses `stderr=subprocess.STDOUT`, the mock will return the specified command's stdout on stdout and the stderr on stderr.  In reality, Popen will return both stdout and stderr in a single stream to stdout.  This should be reflected in the mock as far as is possible.  Obviously we cannot interleave the two streams, but we can concatenate the two and return in one stream.

Is a change like this acceptable?  Happy to tidy up/add doc as required if you can suggest the required changes.