### PR TITLE
Add checker to LogCapture to check that supplied messages are all in captured messages

### DIFF
--- a/testfixtures/logcapture.py
+++ b/testfixtures/logcapture.py
@@ -170,6 +170,22 @@ class LogCapture(logging.Handler):
             recursive=self.recursive_check
             )
 
+    def check_in(self, *expected):
+        """
+        This will check that all expected entries have been captured,
+        or raise an :class:`AssertionError` if any have not
+        :param expected: A sequence of 3-tuples containing the
+                         expected log entries. Each tuple should be of
+                         the form (logger_name, string_level, message) 
+        """
+        captured = tuple(self.actual())
+        for record in expected:
+            if record not in captured:
+                raise AssertionError(
+                    'Could not find {} in captured logging'.format(
+                        record
+                    ))
+
     def __enter__(self):
         return self
 

--- a/testfixtures/tests/test_log_capture.py
+++ b/testfixtures/tests/test_log_capture.py
@@ -211,6 +211,36 @@ class TestLog_Capture(TestCase):
             "While comparing [0][2]: 'oh noez' (expected) != 'oh hai' (actual)"
         ))
 
+    def test_check_in_with_matching_record(self):
+        with LogCapture() as log:
+            logger = getLogger()
+            logger.info('Hello')
+            logger.info('Goodbye')
+        log.check_in(
+            ('root', 'INFO', 'Goodbye')
+        )
+
+    def test_check_in_with_no_matching_record(self):
+        with LogCapture() as log:
+            logger = getLogger()
+            logger.info('Hello')
+            logger.info('Goodbye')
+        with ShouldRaise(AssertionError):
+            log.check_in(
+                ('root', 'INFO', 'Something else')
+            )
+
+    def test_check_in_with_some_matching_records(self):
+        with LogCapture() as log:
+            logger = getLogger()
+            logger.info('Hello')
+            logger.info('Goodbye')
+        with ShouldRaise(AssertionError):
+            log.check_in(
+                ('root', 'INFO', 'Something else'),
+                ('root', 'INFO', 'Hello')
+            )
+
 
 class BaseCaptureTest(TestCase):
     a = 33


### PR DESCRIPTION
I've come to a use case that I'd like to check a one or a small number of messages, all logged to the same logger with the same log level.  Using `LogCapture.check()` requires making assertions I don't care about, but doing `assertIn('Message', str(logs))` is a little too imprecise.

If you're happy with the general approach here, I'll tidy up the assertion and error message and add doc.