### PR TITLE
Allow setting callable for popen behaviour

### DIFF
--- a/docs/popen.txt
+++ b/docs/popen.txt
@@ -148,13 +148,12 @@ Using a callable to define behavior
 -----------------------------------
 
 If you're testing a command which will be called multiple times and will return
-different output each time, you can specify a callable for a specific command
-with :class:`~MockPopen.set_callable` or for commands where no behavior is specified
-with :class:`~MockPopen.set_default_callable`.
+different output each time, you can specify a callable with
+:class:`~MockPopen.set_callable`.
 
-The callable will be called each time the matching command is invoked with the
-command and any standard input provided.  It should return the the arguments to
-:class:`~MockPopen.set_default`.
+The callable will be called each time a command is invoked with the command and
+any standard input provided.  It should return an instance of
+:class:`~PopenBehaviour`.
 
 .. literalinclude:: ../testfixtures/tests/test_popen_docs.py
    :pyobject: TestMyFunc.test_callable

--- a/docs/popen.txt
+++ b/docs/popen.txt
@@ -144,4 +144,21 @@ following example:
    :pyobject: TestMyFunc.test_default_behaviour
    :dedent: 4
 
+Using a callable to define behavior
+-----------------------------------
+
+If you're testing a command which will be called multiple times and will return
+different output each time, you can specify a callable for a specific command
+with :class:`~MockPopen.set_callable` or for commands where no behavior is specified
+with :class:`~MockPopen.set_default_callable`.
+
+The callable will be called each time the matching command is invoked with the
+command and any standard input provided.  It should return the the arguments to
+:class:`~MockPopen.set_default`.
+
+.. literalinclude:: ../testfixtures/tests/test_popen_docs.py
+   :pyobject: TestMyFunc.test_callable
+   :dedent: 4
+
+
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,8 @@ setup(
               'zope.component',
               'django<2;python_version<"3"',
               'django;python_version>="3"',
-              'pytest-django'],
+              'pytest-django',
+              'six'],
         build=['sphinx', 'pkginfo', 'setuptools-git', 'wheel', 'twine']
     )
 )

--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,7 @@ setup(
               'zope.component',
               'django<2;python_version<"3"',
               'django;python_version>="3"',
-              'pytest-django',
-              'six'],
+              'pytest-django'],
         build=['sphinx', 'pkginfo', 'setuptools-git', 'wheel', 'twine']
     )
 )

--- a/testfixtures/tests/test_popen.py
+++ b/testfixtures/tests/test_popen.py
@@ -2,6 +2,7 @@ from subprocess import PIPE, STDOUT
 from unittest import TestCase
 
 from .mock import call
+import six
 from testfixtures import ShouldRaise, compare
 
 from testfixtures.popen import MockPopen
@@ -57,7 +58,7 @@ class Tests(TestCase):
 
     def test_callable(self):
         def some_callable(command, stdin):
-            return bytes(command, encoding='utf8'), bytes(stdin, encoding='utf8'), 1, 345, 0
+            return six.b(command), six.b(stdin), 1, 345, 0
 
         Popen = MockPopen()
         Popen.set_callable('a command', some_callable)
@@ -376,7 +377,7 @@ class Tests(TestCase):
 
     def test_default_callable(self):
         def some_callable(command, stdin):
-            return bytes(command, encoding='utf8'), bytes(stdin, encoding='utf8'), 1, 345, 0
+            return six.b(command), six.b(stdin), 1, 345, 0
 
         Popen = MockPopen()
         Popen.set_default_callable(some_callable)

--- a/testfixtures/tests/test_popen.py
+++ b/testfixtures/tests/test_popen.py
@@ -55,6 +55,22 @@ class Tests(TestCase):
                 call.Popen_instance.communicate(),
                 ], Popen.mock.method_calls)
 
+    def test_callable(self):
+        def some_callable(command, stdin):
+            return bytes(command, encoding='utf8'), bytes(stdin, encoding='utf8'), 1, 345, 0
+
+        Popen = MockPopen()
+        Popen.set_callable('a command', some_callable)
+
+        process = Popen('a command', stdin='some stdin', stdout=PIPE, stderr=PIPE)
+        compare(process.pid, 345)
+
+        out, err = process.communicate()
+
+        compare(out, b'a command')
+        compare(err, b'some stdin')
+        compare(process.returncode, 1)
+
     def test_command_is_sequence(self):
         Popen = MockPopen()
         Popen.set_command('a command')
@@ -357,6 +373,22 @@ class Tests(TestCase):
             call.Popen('a command', stderr=-1, stdout=-1),
             call.Popen_instance.communicate(),
         ], Popen.mock.method_calls)
+
+    def test_default_callable(self):
+        def some_callable(command, stdin):
+            return bytes(command, encoding='utf8'), bytes(stdin, encoding='utf8'), 1, 345, 0
+
+        Popen = MockPopen()
+        Popen.set_default_callable(some_callable)
+
+        process = Popen('a command', stdin='some stdin', stdout=PIPE, stderr=PIPE)
+        compare(process.pid, 345)
+
+        out, err = process.communicate()
+
+        compare(out, b'a command')
+        compare(err, b'some stdin')
+        compare(process.returncode, 1)
 
     def test_invalid_parameters(self):
         Popen = MockPopen()

--- a/testfixtures/tests/test_popen.py
+++ b/testfixtures/tests/test_popen.py
@@ -4,7 +4,7 @@ from unittest import TestCase
 from .mock import call
 from testfixtures import ShouldRaise, compare
 
-from testfixtures.popen import MockPopen
+from testfixtures.popen import MockPopen, PopenBehaviour
 from testfixtures.compat import BytesLiteral, PY2
 
 import signal
@@ -57,10 +57,10 @@ class Tests(TestCase):
 
     def test_callable(self):
         def some_callable(command, stdin):
-            return BytesLiteral(command), BytesLiteral(stdin), 1, 345, 0
+            return PopenBehaviour(BytesLiteral(command), BytesLiteral(stdin), 1, 345, 0)
 
         Popen = MockPopen()
-        Popen.set_callable('a command', some_callable)
+        Popen.set_callable(some_callable)
 
         process = Popen('a command', stdin='some stdin', stdout=PIPE, stderr=PIPE)
         compare(process.pid, 345)
@@ -373,22 +373,6 @@ class Tests(TestCase):
             call.Popen('a command', stderr=-1, stdout=-1),
             call.Popen_instance.communicate(),
         ], Popen.mock.method_calls)
-
-    def test_default_callable(self):
-        def some_callable(command, stdin):
-            return BytesLiteral(command), BytesLiteral(stdin), 1, 345, 0
-
-        Popen = MockPopen()
-        Popen.set_default_callable(some_callable)
-
-        process = Popen('a command', stdin='some stdin', stdout=PIPE, stderr=PIPE)
-        compare(process.pid, 345)
-
-        out, err = process.communicate()
-
-        compare(out, b'a command')
-        compare(err, b'some stdin')
-        compare(process.returncode, 1)
 
     def test_invalid_parameters(self):
         Popen = MockPopen()

--- a/testfixtures/tests/test_popen.py
+++ b/testfixtures/tests/test_popen.py
@@ -2,11 +2,10 @@ from subprocess import PIPE, STDOUT
 from unittest import TestCase
 
 from .mock import call
-import six
 from testfixtures import ShouldRaise, compare
 
 from testfixtures.popen import MockPopen
-from testfixtures.compat import PY2
+from testfixtures.compat import BytesLiteral, PY2
 
 import signal
 
@@ -58,7 +57,7 @@ class Tests(TestCase):
 
     def test_callable(self):
         def some_callable(command, stdin):
-            return six.b(command), six.b(stdin), 1, 345, 0
+            return BytesLiteral(command), BytesLiteral(stdin), 1, 345, 0
 
         Popen = MockPopen()
         Popen.set_callable('a command', some_callable)
@@ -377,7 +376,7 @@ class Tests(TestCase):
 
     def test_default_callable(self):
         def some_callable(command, stdin):
-            return six.b(command), six.b(stdin), 1, 345, 0
+            return BytesLiteral(command), BytesLiteral(stdin), 1, 345, 0
 
         Popen = MockPopen()
         Popen.set_default_callable(some_callable)

--- a/testfixtures/tests/test_popen_docs.py
+++ b/testfixtures/tests/test_popen_docs.py
@@ -17,7 +17,7 @@ from unittest import TestCase
 
 from .mock import call
 from testfixtures import Replacer, ShouldRaise, compare
-from testfixtures.popen import MockPopen
+from testfixtures.popen import MockPopen, PopenBehaviour
 
 
 class TestMyFunc(TestCase):
@@ -157,8 +157,8 @@ class TestMyFunc(TestCase):
     def test_callable(self):
         # set up
         def command_callable(command, stdin):
-            return b'stdout', b'stderr', 0, 1234, 3
-        self.Popen.set_default_callable(command_callable)
+            return PopenBehaviour(stdout=b'stdout')
+        self.Popen.set_callable(command_callable)
 
         # testing of results
         compare(my_func(), b'stdout')

--- a/testfixtures/tests/test_popen_docs.py
+++ b/testfixtures/tests/test_popen_docs.py
@@ -153,3 +153,19 @@ class TestMyFunc(TestCase):
                        shell=True, stderr=PIPE, stdout=PIPE),
             call.Popen_instance.communicate()
             ], Popen.mock.method_calls)
+
+    def test_callable(self):
+        # set up
+        def command_callable(command, stdin):
+            return b'stdout', b'stderr', 0, 1234, 3
+        self.Popen.set_default_callable(command_callable)
+
+        # testing of results
+        compare(my_func(), b'stdout')
+
+        # testing calls were in the right order and with the correct parameters:
+        compare([
+            call.Popen('svn ls -R foo',
+                       shell=True, stderr=PIPE, stdout=PIPE),
+            call.Popen_instance.communicate()
+        ], Popen.mock.method_calls)


### PR DESCRIPTION
Sometimes I need to test calling a command which will have different output each time, typically polling the status of some external system.  Currently this isn't possible.

By allowing setting a callable to be called when the command is actually run, it's possible to achieve this.

One potential concern here are the errors if the specified callable has the wrong signature or returns the wrong number of parameters to be unpacked.  I think the default errors are clear enough here.

Happy to extend tests and doc if needed.
