### PR TITLE
Mockpopen multiple processes

### DIFF
--- a/docs/api.txt
+++ b/docs/api.txt
@@ -28,8 +28,7 @@ API Reference
 .. autoclass:: ShouldRaise
    :members:
 
-.. autoclass:: ShouldAssert
-   :members:
+.. autofunction:: ShouldAssert
 
 .. autoclass:: ShouldWarn
    :members:

--- a/docs/popen.txt
+++ b/docs/popen.txt
@@ -26,6 +26,11 @@ is an attempt to provide just such a mock.
 .. note:: To use :class:`~testfixtures.popen.MockPopen`, you must have the
           :mod:`mock` package installed or be using Python 3.3 or later.
 
+.. warning::
+   Previous versions of this mock made use of :attr:`~unittest.mock.Mock.mock_calls`.
+   These are deceptively incapable of recording some information important in the use
+   of this mock, so please switch to making assertions about
+   :attr:`~MockPopen.all_calls` and :attr:`~MockPopenInstance.calls` instead.
 
 Example usage
 -------------
@@ -36,7 +41,7 @@ test:
 .. literalinclude:: ../testfixtures/tests/test_popen_docs.py
    :lines: 4-12
 
-Tests that exercises this code using :class:`~testfixtures.popen.MockPopen`
+Tests that exercise this code using :class:`~testfixtures.popen.MockPopen`
 could be written as follows:
 
 .. literalinclude:: ../testfixtures/tests/test_popen_docs.py
@@ -60,7 +65,8 @@ when you check the calls on the mock as shown in this example:
 Reading from ``stdout`` and ``stderr``
 --------------------------------------
 
-The ``.stdout`` and ``.stderr`` attributes of the mock returned by
+The :attr:`~MockPopenInstance.stdout` and :attr:`~MockPopenInstance.stderr`
+attributes of the mock returned by
 :class:`~testfixtures.popen.MockPopen` will be file-like objects as with
 the real :class:`~subprocess.Popen` and can be read as shown in this example:
 
@@ -73,14 +79,15 @@ the real :class:`~subprocess.Popen` and can be read as shown in this example:
     While these streams behave a lot like the streams of a real
     :class:`~subprocess.Popen` object, they do not exhibit the deadlocking
     behaviour that can occur when the two streams are read as in the example
-    above. Be very careful when reading ``.stdout`` and ``.stderr`` and
-    consider using :class:`~subprocess.Popen.communicate` instead.
+    above. Be very careful when reading :attr:`~MockPopenInstance.stdout` and
+    :attr:`~MockPopenInstance.stderr` and
+    consider using :meth:`~subprocess.Popen.communicate` instead.
 
 
 Writing to ``stdin``
 --------------------
-
-If you set ``stdin=PIPE`` in your call to ``Popen`` then the ``stdin``
+If you set ``stdin=PIPE`` in your call to :class:`~subprocess.Popen` then the
+:attr:`~MockPopenInstance.stdin`
 attribute of the mock returned by :class:`~testfixtures.popen.MockPopen`
 will be a mock and you can then examine the write calls to it as shown
 in this example:
@@ -105,8 +112,9 @@ following example:
 Checking for signal sending
 ---------------------------
 
-Calls to ``.send_signal()``, ``.terminate()`` and  ``.kill()`` are all recorded
-by the mock returned by :class:`~testfixtures.popen.MockPopen`
+Calls to :meth:`~MockPopenInstance.send_signal`,
+:meth:`MockPopenInstance.terminate` and :meth:`MockPopenInstance.kill` are all
+recorded by the mock returned by :class:`~testfixtures.popen.MockPopen`
 but otherwise do nothing as shown in the following example, which doesn't
 make sense for a real test of sub-process usage but does show how the mock
 behaves:
@@ -121,16 +129,18 @@ Polling a process
 The :meth:`~subprocess.Popen.poll` method is often used as part of a loop
 in order to do other work while waiting for a sub-process to complete.
 The mock returned by :class:`~testfixtures.popen.MockPopen` supports this
-by allowing the ``.poll()`` method to be called a number of times before
-the ``returncode`` is set using the ``poll_count`` parameter as shown in
+by allowing the :meth:`~MockPopenInstance.poll` method to
+be called a number of times before
+the :attr:`~MockPopenInstance.returncode` is set using the
+``poll_count`` parameter as shown in
 the following example:
 
 .. literalinclude:: ../testfixtures/tests/test_popen_docs.py
    :pyobject: TestMyFunc.test_poll_until_result
    :dedent: 4
 
-Multiple process executions
----------------------------
+Different behaviour on sequential processes
+-------------------------------------------
 
 If your code needs to call the same command but have different behaviour
 on each call, then you can pass a callable behaviour like this:
@@ -139,7 +149,8 @@ on each call, then you can pass a callable behaviour like this:
    :pyobject: TestMyFunc.test_multiple_responses
    :dedent: 4
 
-If you need to keep state across calls, such as accumulating ``stdin`` on
+If you need to keep state across calls, such as accumulating
+:attr:`~MockPopenInstance.stdin` or
 failing for a configurable number of calls, then wrap that behaviour up
 into a class:
 
@@ -168,17 +179,26 @@ following example:
    :pyobject: TestMyFunc.test_default_behaviour
    :dedent: 4
 
-Using a callable to define behavior
------------------------------------
 
-If you're testing a command which will be called multiple times and will return
-different output each time, you can pass a callable to
-:class:`~MockPopen.set_default`.
+Tracking multiple simultaneous processes
+----------------------------------------
 
-The callable will be called each time a command is invoked and will be passed the
-command and any standard input provided.  It should return an instance of
-:class:`~PopenBehaviour`.
+Conversely, if you're testing something that spins up multiple subprocesses
+and manages their simultaneous execution, you will want to explicitly define the
+behaviour of each process using :class:`~MockPopen.set_command` and then make
+assertions about each process using :attr:`~MockPopen.all_calls`.
+
+For example, suppose we wanted to test this function:
 
 .. literalinclude:: ../testfixtures/tests/test_popen_docs.py
-   :pyobject: TestMyFunc.test_callable
+   :pyobject: process_in_batches
+
+Then you could test it as follows:
+
+.. literalinclude:: ../testfixtures/tests/test_popen_docs.py
+   :pyobject: TestMyFunc.test_multiple_processes
    :dedent: 4
+
+Note that the order of all calls is explicitly recorded. If the order of these calls
+is non-deterministic due to your method of process management, you will need to
+do more work and be very careful when testing.

--- a/testfixtures/compat.py
+++ b/testfixtures/compat.py
@@ -26,6 +26,7 @@ if PY_VERSION > (3, 0):
     from io import StringIO
     xrange = range
     from itertools import zip_longest
+    from functools import reduce
 
 else:
 
@@ -46,6 +47,7 @@ else:
     from StringIO import StringIO
     xrange = xrange
     from itertools import izip_longest as zip_longest
+    reduce = reduce
 
 try:
     from mock import call as mock_call

--- a/testfixtures/popen.py
+++ b/testfixtures/popen.py
@@ -5,10 +5,7 @@ from tempfile import TemporaryFile
 from testfixtures.compat import basestring, PY3, zip_longest, reduce
 from testfixtures.utils import extend_docstring
 
-try:
-    from unittest.mock import Mock, call
-except ImportError:
-    from mock import Mock, call
+from .mock import Mock, call
 
 
 class PopenBehaviour(object):

--- a/testfixtures/tests/test_popen.py
+++ b/testfixtures/tests/test_popen.py
@@ -193,10 +193,21 @@ class Tests(TestCase):
         process = Popen('a command', stdin=PIPE, shell=True)
         process.stdin.write('some text')
         # test call list
-        compare([
-                call.Popen('a command', shell=True, stdin=PIPE),
-                call.Popen_instance.stdin.write('some text'),
-                ], Popen.mock.method_calls)
+        compare(Popen.mock.method_calls, expected=[
+            call.Popen('a command', shell=True, stdin=PIPE),
+            call.Popen_instance.stdin.write('some text'),
+        ])
+        compare(Popen.all_calls, expected=[
+            call.Popen('a command', shell=True, stdin=PIPE),
+            call.Popen('a command', shell=True, stdin=PIPE).stdin.write('some text'),
+        ])
+        compare(process.mock.method_calls, expected=[
+            call.stdin.write('some text'),
+        ])
+        compare(process.calls, expected=[
+            call.stdin.write('some text'),
+        ])
+        repr(call.stdin.write('some text'))
 
     def test_wait_and_return_code(self):
         # setup
@@ -565,6 +576,20 @@ class Tests(TestCase):
         process_b = Popen(['b', 'command'], stdout=PIPE, stderr=PIPE, shell=True)
         compare(process_a.wait(), expected=1)
         compare(process_b.wait(), expected=2)
+        a_call = call.Popen('a command', stdout=PIPE, stderr=PIPE, shell=True)
+        b_call = call.Popen(['b', 'command'], stdout=PIPE, stderr=PIPE, shell=True)
+        compare(Popen.all_calls, expected=[
+                a_call,
+                b_call,
+                a_call.wait(),
+                b_call.wait(),
+        ])
+        compare(process_a.mock.method_calls, expected=[
+            call.wait()
+        ])
+        compare(process_b.mock.method_calls, expected=[
+            call.wait()
+        ])
 
 
 class IntegrationTests(TestCase):

--- a/testfixtures/tests/test_popen.py
+++ b/testfixtures/tests/test_popen.py
@@ -97,6 +97,24 @@ class Tests(TestCase):
                 call.Popen_instance.communicate('foo'),
                 ], Popen.mock.method_calls)
 
+    def test_communicate_with_timeout(self):
+        Popen = MockPopen()
+        Popen.set_command('a command', returncode=3)
+        process = Popen('a command')
+        if PY2:
+            with ShouldRaise(TypeError):
+                process.communicate(timeout=1)
+            with ShouldRaise(TypeError):
+                process.communicate('foo', 1)
+        else:
+            process.communicate(timeout=1)
+            process.communicate('foo', 1)
+            compare([
+                call.Popen('a command'),
+                call.Popen_instance.communicate(timeout=1),
+                call.Popen_instance.communicate('foo', 1),
+            ], expected=Popen.mock.method_calls)
+
     def test_read_from_stdout(self):
         # setup
         Popen = MockPopen()
@@ -195,6 +213,24 @@ class Tests(TestCase):
                 call.Popen('a command'),
                 call.Popen_instance.wait(),
                 ], Popen.mock.method_calls)
+
+    def test_wait_timeout(self):
+        Popen = MockPopen()
+        Popen.set_command('a command', returncode=3)
+        process = Popen('a command')
+        if PY2:
+            with ShouldRaise(TypeError):
+                process.wait(timeout=1)
+            with ShouldRaise(TypeError):
+                process.wait(1)
+        else:
+            process.wait(timeout=1)
+            process.wait(1)
+            compare([
+                call.Popen('a command'),
+                call.Popen_instance.wait(timeout=1),
+                call.Popen_instance.wait(1)
+            ], expected=Popen.mock.method_calls)
 
     def test_multiple_uses(self):
         Popen = MockPopen()

--- a/testfixtures/tests/test_popen.py
+++ b/testfixtures/tests/test_popen.py
@@ -414,7 +414,7 @@ class Tests(TestCase):
     def test_invalid_parameters(self):
         Popen = MockPopen()
         with ShouldRaise(TypeError(
-                "Popen() got an unexpected keyword argument 'foo'"
+                "__init__() got an unexpected keyword argument 'foo'"
         )):
             Popen(foo='bar')
 
@@ -422,15 +422,14 @@ class Tests(TestCase):
         Popen = MockPopen()
         Popen.set_command('command')
         process = Popen('command')
-        with ShouldRaise(
-                AttributeError("Mock object has no attribute 'foo'")):
+        with ShouldRaise(AttributeError):
             process.foo()
 
     def test_invalid_attribute(self):
         Popen = MockPopen()
         Popen.set_command('command')
         process = Popen('command')
-        with ShouldRaise(AttributeError("Mock object has no attribute 'foo'")):
+        with ShouldRaise(AttributeError):
             process.foo
 
     def test_invalid_communicate_call(self):
@@ -557,6 +556,15 @@ class Tests(TestCase):
         compare([
             call.Popen('a command', start_new_session=True),
         ], Popen.mock.method_calls)
+
+    def test_simultaneous_processes(self):
+        Popen = MockPopen()
+        Popen.set_command('a command', b'a', returncode=1)
+        Popen.set_command('b command', b'b', returncode=2)
+        process_a = Popen('a command', stdout=PIPE, stderr=PIPE, shell=True)
+        process_b = Popen(['b', 'command'], stdout=PIPE, stderr=PIPE, shell=True)
+        compare(process_a.wait(), expected=1)
+        compare(process_b.wait(), expected=2)
 
 
 class IntegrationTests(TestCase):


### PR DESCRIPTION
This will fix #90 but still to do:
- fix `mock.call`: https://bugs.python.org/issue35226 - which will mean a fix in testfixtures in the meantime.
- fix PRs to testfixtures so that coverage checks work as required.
- update `MockPopen` docs to recommend using `all_calls` or a process' `calls` when checking what was called.