### PR TITLE
Address recent changes to unittest.mock.call (3.6.8, 3.7.2, python-next)

### DIFF
--- a/testfixtures/comparison.py
+++ b/testfixtures/comparison.py
@@ -6,8 +6,8 @@ from types import GeneratorType
 
 from testfixtures import not_there
 from testfixtures.compat import (
-    ClassType, Unicode, basestring, mock_call, unittest_mock_call,
-    PY3)
+    ClassType, Unicode, basestring, mock_call, mock_call_parent_attribute,
+    unittest_mock_call, PY3)
 from testfixtures.resolve import resolve
 from testfixtures.utils import indent
 
@@ -318,7 +318,11 @@ def compare_call(x, y, context):
     x_name, x_args, x_kw = x
     y_name, y_args, y_kw = y
     if x_name == y_name and x_args == y_args and x_kw == y_kw:
-        return compare_call(x.parent, y.parent, context)
+        return compare_call(
+            getattr(x, mock_call_parent_attribute),
+            getattr(y, mock_call_parent_attribute),
+            context,
+        )
     return compare_text(repr(x), repr(y), context)
 
 

--- a/testfixtures/compat.py
+++ b/testfixtures/compat.py
@@ -2,6 +2,7 @@
 import sys
 
 PY_VERSION = sys.version_info[:2]
+PY_VERSION_LONG = sys.version_info[:3]
 
 PY_36_PLUS = PY_VERSION >= (3, 6)
 PY_37_PLUS = PY_VERSION >= (3, 7)
@@ -27,6 +28,11 @@ if PY_VERSION > (3, 0):
     xrange = range
     from itertools import zip_longest
     from functools import reduce
+    if (3, 6, 8) <= PY_VERSION_LONG < (3, 7) or PY_VERSION_LONG >= (3, 7, 2):
+        # https://bugs.python.org/issue35357
+        mock_call_parent_attribute = '_mock_parent'
+    else:
+        mock_call_parent_attribute = 'parent'
 
 else:
 
@@ -48,6 +54,7 @@ else:
     xrange = xrange
     from itertools import izip_longest as zip_longest
     reduce = reduce
+    mock_call_parent_attribute = 'parent'
 
 try:
     from mock import call as mock_call

--- a/testfixtures/mock.py
+++ b/testfixtures/mock.py
@@ -20,6 +20,8 @@ except ImportError:
     from unittest.mock import *
     from unittest.mock import _Call
 
+from testfixtures.compat import mock_call_parent_attribute
+
 
 def __eq__(self, other):
     if other is ANY:
@@ -35,8 +37,9 @@ def __eq__(self, other):
     else:
         self_name, self_args, self_kwargs = self
 
-    if (getattr(self, 'parent', None) and getattr(other, 'parent', None)
-            and self.parent != other.parent):
+    our_parent = getattr(self, mock_call_parent_attribute, None)
+    other_parent = getattr(other, mock_call_parent_attribute, None)
+    if our_parent and other_parent and our_parent != other_parent:
         return False
 
     other_name = ''


### PR DESCRIPTION
In python 3.6.8, 3.7.2, and in python-next, some attributes on the
unittest.mock.call object were renamed from things like `name` and
`parent` to `_mock_name` and `_mock_parent`.

resolves #102

Python bug:

* bpo-35357 (https://bugs.python.org/issue35357)

pull requests which added this change:

* python/cpython#10873
* python/cpython#10887
* python/cpython#10888