### PR TITLE
Import `Iterable` from the non-deprecated location.

### DIFF
--- a/testfixtures/comparison.py
+++ b/testfixtures/comparison.py
@@ -1,4 +1,4 @@
-from collections import Iterable
+from collections.abc import Iterable
 from difflib import unified_diff
 from functools import partial
 from pprint import pformat

--- a/testfixtures/comparison.py
+++ b/testfixtures/comparison.py
@@ -1,4 +1,3 @@
-from collections.abc import Iterable
 from difflib import unified_diff
 from functools import partial
 from pprint import pformat
@@ -6,7 +5,7 @@ from re import compile, MULTILINE
 from types import GeneratorType
 
 from testfixtures import not_there
-from testfixtures.compat import ClassType, Unicode, basestring, PY3
+from testfixtures.compat import ClassType, Iterable, Unicode, basestring, PY3
 from testfixtures.resolve import resolve
 from testfixtures.utils import indent
 from testfixtures.mock import parent_name, mock_call, unittest_mock_call

--- a/testfixtures/compat.py
+++ b/testfixtures/compat.py
@@ -27,6 +27,7 @@ if PY_VERSION > (3, 0):
     xrange = range
     from itertools import zip_longest
     from functools import reduce
+    from collections.abc import Iterable
 
 else:
 
@@ -48,3 +49,4 @@ else:
     xrange = xrange
     from itertools import izip_longest as zip_longest
     reduce = reduce
+    from collections import Iterable


### PR DESCRIPTION
When using the `testfixtures` package in a python 3.7 environment, deprecation warnings are visible:
```
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
```
Also see the note about `Changed in version 3.3: Moved Collections Abstract Base Classes to the collections.abc module` at: https://docs.python.org/3.7/library/collections.html