### PR TITLE
compare(): Add support for naming x/y kwargs and document x/y_label kwargs

### DIFF
--- a/testfixtures/comparison.py
+++ b/testfixtures/comparison.py
@@ -455,6 +455,13 @@ class CompareContext(object):
         if actual is not not_there:
             possible.append(actual)
 
+        x = self.options.pop('x', not_there)
+        if x is not not_there:
+            possible.append(x)
+        y = self.options.pop('y', not_there)
+        if y is not not_there:
+            possible.append(y)
+
         if len(possible) != 2:
             message = 'Exactly two objects needed, you supplied:'
             if possible:
@@ -555,11 +562,13 @@ class CompareContext(object):
 
 def compare(*args, **kw):
     """
-    Compare the two arguments passed either positionally or using
-    explicit ``expected`` and ``actual`` keyword paramaters. An
-    :class:`AssertionError` will be raised if they are not the same.
-    The :class:`AssertionError` raised will attempt to provide
+    Compare two objects, raising an :class:`AssertionError` if they are not
+    the same. The :class:`AssertionError` raised will attempt to provide
     descriptions of the differences found.
+
+    The two objects to compare can be passed either positionally or using
+    explicit keyword arguments named ``x`` and ``y``, or ``expected`` and
+    ``actual``.
 
     Any other keyword parameters supplied will be passed to the functions
     that end up doing the comparison. See the API documentation below
@@ -572,6 +581,18 @@ def compare(*args, **kw):
     :param suffix: If provided, in the event of an :class:`AssertionError`
                    being raised, the suffix supplied will be appended to the
                    message in the :class:`AssertionError`.
+
+    :param x_label: If provided, in the event of an :class:`AssertionError`
+                    being raised, the object passed as the first positional
+                    argument, or ``x`` keyword argument, will be labelled
+                    with this string in the message in the
+                    :class:`AssertionError`.
+
+    :param x_label: If provided, in the event of an :class:`AssertionError`
+                    being raised, the object passed as the second positional
+                    argument, or ``y`` keyword argument, will be labelled
+                    with this string in the message in the
+                    :class:`AssertionError`.
 
     :param raises: If ``False``, the message that would be raised in the
                    :class:`AssertionError` will be returned instead of the

--- a/testfixtures/tests/test_compare.py
+++ b/testfixtures/tests/test_compare.py
@@ -44,6 +44,11 @@ class CompareHelper(object):
         for value in x, y:
             if value is not marker:
                 args.append(value)
+        for value in 'x', 'y':
+            explicit = 'explicit_{}'.format(value)
+            if explicit in kw:
+                kw[value] = kw[explicit]
+                del kw[explicit]
         try:
             compare(*args, **kw)
         except Exception as e:
@@ -1353,13 +1358,18 @@ b
                           message="'x' (expected) != 'y' (actual)")
 
     def test_explicit_both(self):
-        self.check_raises(message="'x' (expected) != 'y' (actual)",
-                          expected='x', actual='y')
+        self.check_raises(expected='x', actual='y',
+                          message="'x' (expected) != 'y' (actual)")
+
+    def test_implicit_and_labels(self):
+        self.check_raises('x', 'y',
+                          x_label='x_label', y_label='y_label',
+                          message="'x' (x_label) != 'y' (y_label)")
 
     def test_explicit_and_labels(self):
-        self.check_raises(message="'x' (x_label) != 'y' (y_label)",
-                          expected='x', actual='y',
-                          x_label='x_label', y_label='y_label')
+        self.check_raises(explicit_x='x', explicit_y='y',
+                          x_label='x_label', y_label='y_label',
+                          message="'x' (x_label) != 'y' (y_label)")
 
     def test_invalid_two_args_expected(self):
         with ShouldRaise(TypeError(


### PR DESCRIPTION
Fixes #123