### PR TITLE
Restore ability for Comparison() to compare properties (and methods)

### DIFF
--- a/testfixtures/comparison.py
+++ b/testfixtures/comparison.py
@@ -697,15 +697,19 @@ class Comparison(object):
         if self.v is None:
             return True
 
+        remaining_keys = set(self.v.keys())
         if self.strict:
             v = _extract_attrs(other)
+            remaining_keys -= set(v.keys())
         else:
             v = {}
-            for k in self.v.keys():
-                try:
-                    v[k] = getattr(other, k)
-                except AttributeError:
-                    pass
+
+        while remaining_keys:
+            k = remaining_keys.pop()
+            try:
+                v[k] = getattr(other, k)
+            except AttributeError:
+                pass
 
         kw = {'x_label': 'Comparison', 'y_label': 'actual'}
         context = CompareContext(kw)

--- a/testfixtures/tests/test_comparison.py
+++ b/testfixtures/tests/test_comparison.py
@@ -427,38 +427,70 @@ class TestC(TestCase):
             AClass(1, 2),
             )
 
-    def test_property_strict(self):
-        self.run_property_test(strict=True)
+    def test_property_equal_strict(self):
+        self.run_property_equal_test(strict=True)
 
-    def test_property_not_strict(self):
-        self.run_property_test(strict=False)
+    def test_property_equal_not_strict(self):
+        self.run_property_equal_test(strict=False)
 
-    def run_property_test(self, strict):
-        value = object()
-
+    def run_property_equal_test(self, strict):
         class SomeClass(object):
             @property
             def prop(self):
-                return value
+                return 1
 
         self.assertEqual(
-            C(SomeClass, prop=value, strict=strict),
+            C(SomeClass, prop=1, strict=strict),
             SomeClass()
         )
 
-    def test_method_strict(self):
-        self.run_property_test(strict=True)
+    def test_property_not_equal_strict(self):
+        self.run_property_not_equal_test(strict=True)
 
-    def test_method_not_strict(self):
-        self.run_property_test(strict=False)
+    def test_property_not_equal_not_strict(self):
+        self.run_property_not_equal_test(strict=False)
 
-    def run_method_test(self, strict):
+    def run_property_not_equal_test(self, strict):
+        class SomeClass(object):
+            @property
+            def prop(self):
+                return 1
+
+        self.assertNotEqual(
+            C(SomeClass, prop=2, strict=strict),
+            SomeClass()
+        )
+
+    def test_method_equal_strict(self):
+        self.run_method_equal_test(strict=True)
+
+    def test_method_equal_not_strict(self):
+        self.run_method_equal_test(strict=False)
+
+    def run_method_equal_test(self, strict):
         class SomeClass(object):
             def meth(self):
                 pass
 
+        instance = SomeClass()
         self.assertEqual(
-            C(SomeClass, meth=SomeClass.meth, strict=strict),
+            C(SomeClass, meth=instance.meth, strict=strict),
+            instance
+        )
+
+    def test_method_not_equal_strict(self):
+        self.run_method_not_equal_test(strict=True)
+
+    def test_method_not_equal_not_strict(self):
+        self.run_method_not_equal_test(strict=False)
+
+    def run_method_not_equal_test(self, strict):
+        class SomeClass(object):
+            def meth(self):
+                pass
+
+        self.assertNotEqual(
+            C(SomeClass, meth=object.__init__, strict=strict),
             SomeClass()
         )
 

--- a/testfixtures/tests/test_comparison.py
+++ b/testfixtures/tests/test_comparison.py
@@ -469,12 +469,12 @@ class TestC(TestCase):
 
     def run_method_equal_test(self, strict):
         class SomeClass(object):
-            def meth(self):
-                pass
+            def method(self):
+                pass  # pragma: no cover
 
         instance = SomeClass()
         self.assertEqual(
-            C(SomeClass, meth=instance.meth, strict=strict),
+            C(SomeClass, method=instance.method, strict=strict),
             instance
         )
 
@@ -486,11 +486,11 @@ class TestC(TestCase):
 
     def run_method_not_equal_test(self, strict):
         class SomeClass(object):
-            def meth(self):
-                pass
+            def method(self):
+                pass  # pragma: no cover
 
         self.assertNotEqual(
-            C(SomeClass, meth=object.__init__, strict=strict),
+            C(SomeClass, method=object.__init__, strict=strict),
             SomeClass()
         )
 

--- a/testfixtures/tests/test_comparison.py
+++ b/testfixtures/tests/test_comparison.py
@@ -427,12 +427,6 @@ class TestC(TestCase):
             AClass(1, 2),
             )
 
-    def test_property_equal_strict(self):
-        self.run_property_equal_test(strict=True)
-
-    def test_property_equal_not_strict(self):
-        self.run_property_equal_test(strict=False)
-
     def run_property_equal_test(self, strict):
         class SomeClass(object):
             @property
@@ -444,11 +438,11 @@ class TestC(TestCase):
             SomeClass()
         )
 
-    def test_property_not_equal_strict(self):
-        self.run_property_not_equal_test(strict=True)
+    def test_property_equal_strict(self):
+        self.run_property_equal_test(strict=True)
 
-    def test_property_not_equal_not_strict(self):
-        self.run_property_not_equal_test(strict=False)
+    def test_property_equal_not_strict(self):
+        self.run_property_equal_test(strict=False)
 
     def run_property_not_equal_test(self, strict):
         class SomeClass(object):
@@ -456,16 +450,21 @@ class TestC(TestCase):
             def prop(self):
                 return 1
 
-        self.assertNotEqual(
-            C(SomeClass, prop=2, strict=strict),
-            SomeClass()
-        )
+        c = C(SomeClass, prop=2, strict=strict)
+        self.assertNotEqual(c, SomeClass())
+        compare_repr(
+            c,
+            "\n"
+            "<C(failed):testfixtures.tests.test_comparison.SomeClass>\n"
+            "attributes differ:\n"
+            "'prop': 2 (Comparison) != 1 (actual)\n"
+            "</C>")
 
-    def test_method_equal_strict(self):
-        self.run_method_equal_test(strict=True)
+    def test_property_not_equal_strict(self):
+        self.run_property_not_equal_test(strict=True)
 
-    def test_method_equal_not_strict(self):
-        self.run_method_equal_test(strict=False)
+    def test_property_not_equal_not_strict(self):
+        self.run_property_not_equal_test(strict=False)
 
     def run_method_equal_test(self, strict):
         class SomeClass(object):
@@ -478,21 +477,34 @@ class TestC(TestCase):
             instance
         )
 
+    def test_method_equal_strict(self):
+        self.run_method_equal_test(strict=True)
+
+    def test_method_equal_not_strict(self):
+        self.run_method_equal_test(strict=False)
+
+    def run_method_not_equal_test(self, strict):
+        class SomeClass(object): pass
+        instance = SomeClass()
+        instance.method = min
+
+        c = C(SomeClass, method=max, strict=strict)
+        self.assertNotEqual(c, instance)
+        compare_repr(
+            c,
+            "\n"
+            "<C(failed):testfixtures.tests.test_comparison.SomeClass>\n"
+            "attributes differ:\n"
+            "'method': <built-in function max> (Comparison)"
+            " != <built-in function min> (actual)\n"
+            "</C>"
+        )
+
     def test_method_not_equal_strict(self):
         self.run_method_not_equal_test(strict=True)
 
     def test_method_not_equal_not_strict(self):
         self.run_method_not_equal_test(strict=False)
-
-    def run_method_not_equal_test(self, strict):
-        class SomeClass(object):
-            def method(self):
-                pass  # pragma: no cover
-
-        self.assertNotEqual(
-            C(SomeClass, method=object.__init__, strict=strict),
-            SomeClass()
-        )
 
     def test_exception(self):
         self.assertEqual(

--- a/testfixtures/tests/test_comparison.py
+++ b/testfixtures/tests/test_comparison.py
@@ -427,6 +427,41 @@ class TestC(TestCase):
             AClass(1, 2),
             )
 
+    def test_property_strict(self):
+        self.run_property_test(strict=True)
+
+    def test_property_not_strict(self):
+        self.run_property_test(strict=False)
+
+    def run_property_test(self, strict):
+        value = object()
+
+        class SomeClass(object):
+            @property
+            def prop(self):
+                return value
+
+        self.assertEqual(
+            C(SomeClass, prop=value, strict=strict),
+            SomeClass()
+        )
+
+    def test_method_strict(self):
+        self.run_property_test(strict=True)
+
+    def test_method_not_strict(self):
+        self.run_property_test(strict=False)
+
+    def run_method_test(self, strict):
+        class SomeClass(object):
+            def meth(self):
+                pass
+
+        self.assertEqual(
+            C(SomeClass, meth=SomeClass.meth, strict=strict),
+            SomeClass()
+        )
+
     def test_exception(self):
         self.assertEqual(
             ValueError('foo'),


### PR DESCRIPTION
...even in `strict` mode. (This was previously working before v6.0.0)

Fixes #122