### PR TITLE
Correct confusing name and fix typos

### DIFF
--- a/docs/datetime.txt
+++ b/docs/datetime.txt
@@ -12,7 +12,7 @@ this.
 Dates
 ~~~~~
 
-The testfixtures module provides the :func:`~testfixtures.test_date` function
+The testfixtures package provides the :func:`~testfixtures.test_date` function
 that returns a subclass of :class:`datetime.date` with a
 :meth:`~datetime.date.today` method that will return a
 consistent sequence of dates each time it is called.
@@ -99,7 +99,7 @@ this will be the set date plus the ``delta`` in effect:
 Datetimes
 ~~~~~~~~~
 
-The testfixtures module provides the :func:`~testfixtures.test_datetime`
+The testfixtures package provides the :func:`~testfixtures.test_datetime`
 function that returns a subclass of :class:`datetime.datetime` with
 a :meth:`~datetime.datetime.now` method that will return a
 consistent sequence of :obj:`~datetime.datetime` objects each time
@@ -294,7 +294,7 @@ Likewise, :meth:`~tdatetime.add` behaves the same way:
 Times
 ~~~~~
 
-The testfixtures module provides the :func:`~testfixtures.test_time`
+The testfixtures package provides the :func:`~testfixtures.test_time`
 function that, when called, returns a replacement for the
 :func:`time.time` function.
 

--- a/docs/datetime.txt
+++ b/docs/datetime.txt
@@ -6,13 +6,13 @@ Mocking dates and times
 Testing code that involves dates and times or which has behaviour
 dependent on the date or time it is executed at has historically been
 tricky. Mocking lets you perform tests on this type of code and
-TestFixtures provides three specialised mock objects to help with
+testfixtures provides three specialised mock objects to help with
 this. 
 
 Dates
 ~~~~~
 
-TestFixtures provides the :func:`~testfixtures.test_date` function
+The testfixtures module provides the :func:`~testfixtures.test_date` function
 that returns a subclass of :class:`datetime.date` with a
 :meth:`~datetime.date.today` method that will return a
 consistent sequence of dates each time it is called.
@@ -99,7 +99,7 @@ this will be the set date plus the ``delta`` in effect:
 Datetimes
 ~~~~~~~~~
 
-TextFixtures provides the :func:`~testfixtures.test_datetime`
+The testfixtures module provides the :func:`~testfixtures.test_datetime`
 function that returns a subclass of :class:`datetime.datetime` with
 a :meth:`~datetime.datetime.now` method that will return a
 consistent sequence of :obj:`~datetime.datetime` objects each time
@@ -294,7 +294,7 @@ Likewise, :meth:`~tdatetime.add` behaves the same way:
 Times
 ~~~~~
 
-TextFixtures provides the :func:`~testfixtures.test_time`
+The testfixtures module provides the :func:`~testfixtures.test_time`
 function that, when called, returns a replacement for the
 :func:`time.time` function.
 


### PR DESCRIPTION
The documentation is about the `testfxtures` module; remove confusing references to the class-like `TestFixtures` name.
Also fix the completely wrong references to `TestFixtures`.