### PR TITLE
Always compare object mappings when ignore_eq is enabled.

### DIFF
--- a/testfixtures/comparison.py
+++ b/testfixtures/comparison.py
@@ -100,7 +100,7 @@ def compare_object(x, y, context, ignore_attributes=()):
     y_attrs = _extract_attrs(y, _attrs_to_ignore(context, ignore_attributes, y))
     if x_attrs is None or y_attrs is None or not (x_attrs and y_attrs):
         return compare_simple(x, y, context)
-    if x_attrs != y_attrs:
+    if context.ignore_eq or x_attrs != y_attrs:
         return _compare_mapping(x_attrs, y_attrs, context, x,
                                 'attributes ', '.%s')
 

--- a/testfixtures/tests/test_compare.py
+++ b/testfixtures/tests/test_compare.py
@@ -1508,6 +1508,25 @@ b
             ignore_eq=True
         )
 
+    def test_nested_django_orm_in_object(self):
+        class MyObject(object):
+            def __init__(self, orm):
+                self.orm = orm
+
+        self.check_raises(
+            message="MyObject not as expected:\n"
+                    "\n"
+                    "attributes differ:\n"
+                    "'orm': OrmObj: 1 (expected) != OrmObj: 2 (actual)\n"
+                    "\n"
+                    "While comparing .orm: OrmObj not as expected:\n"
+                    "\n"
+                    "attributes differ:\n"
+                    "'a': 1 (expected) != 2 (actual)",
+            expected=MyObject(self.OrmObj(1)),
+            actual=MyObject(self.OrmObj(2)),
+            ignore_eq=True)
+
     def test_mock_call_same(self):
         m = Mock()
         m.foo(1, 2, x=3)


### PR DESCRIPTION
The object comparer indirectly relies on the ` __eq__` method of attributes in the check `x_attrs != y_attrs` even when ignore_eq is set.

This PR changes it to always compare the mappings when ignore_eq is enabled. I have also created a test case using the OrmObj object.

The test_compare.py passes on its own; however when I installed Django to run the other tests; I ran into this error using `pytest testfixtures/tests/test_django/test_compare.py`:
```
E   django.core.exceptions.ImproperlyConfigured: Requested setting INSTALLED_APPS, but settings are not configured. You must either define the environment variable DJANGO_SETTINGS_MODULE or call settings.configure() before accessing settings.
```
I am not sure how to run the tests properly.