### PR TITLE
Fixing object compare on boolean list returns

### DIFF
--- a/testfixtures/comparison.py
+++ b/testfixtures/comparison.py
@@ -17,11 +17,23 @@ from testfixtures.utils import indent
 from testfixtures.mock import parent_name, mock_call, unittest_mock_call
 
 
+def _all(eq):
+    if isinstance(eq, bool):
+        return eq
+    elif len(eq) > 0:
+        return all(eq)
+
+def _any(neq):
+    if isinstance(neq, bool):
+        return neq
+    elif len(neq) > 0:
+        return any(neq)
+
 def compare_simple(x, y, context):
     """
     Returns a very simple textual difference between the two supplied objects.
     """
-    if x != y:
+    if _any(x != y):
         repr_x = repr(x)
         repr_y = repr(y)
         if repr_x == repr_y:
@@ -98,6 +110,7 @@ def compare_object(x, y, context, ignore_attributes=()):
         return compare_simple(x, y, context)
     x_attrs = _extract_attrs(x, _attrs_to_ignore(context, ignore_attributes, x))
     y_attrs = _extract_attrs(y, _attrs_to_ignore(context, ignore_attributes, y))
+
     if x_attrs is None or y_attrs is None or not (x_attrs and y_attrs):
         return compare_simple(x, y, context)
     if context.ignore_eq or x_attrs != y_attrs:
@@ -551,13 +564,6 @@ class CompareContext(object):
     def _separator(self):
         return '\n\nWhile comparing %s: ' % ''.join(self.breadcrumbs[1:])
 
-    def _all(self, eq):
-        if isinstance(eq, bool):
-            return eq
-        elif len(eq) > 1:
-            return all(eq)
-
-
     def seen(self, x, y):
         # don't get confused by string interning:
         if isinstance(x, basestring) and isinstance(y, basestring):
@@ -580,12 +586,11 @@ class CompareContext(object):
         self.message = ''
         current_message = ''
         try:
-
-            if not (self.strict or self.ignore_eq) and self._all(x == y):
+            if not (self.strict or self.ignore_eq) and _all(x == y):
                 return False
 
             comparer = self._lookup(x, y)
-
+    
             result = comparer(x, y, self)
             specific_comparer = comparer is not compare_simple
 

--- a/testfixtures/comparison.py
+++ b/testfixtures/comparison.py
@@ -551,6 +551,13 @@ class CompareContext(object):
     def _separator(self):
         return '\n\nWhile comparing %s: ' % ''.join(self.breadcrumbs[1:])
 
+    def _all(self, eq):
+        if isinstance(eq, bool):
+            return eq
+        elif len(eq) > 1:
+            return all(eq)
+
+
     def seen(self, x, y):
         # don't get confused by string interning:
         if isinstance(x, basestring) and isinstance(y, basestring):
@@ -574,7 +581,7 @@ class CompareContext(object):
         current_message = ''
         try:
 
-            if not (self.strict or self.ignore_eq) and x == y:
+            if not (self.strict or self.ignore_eq) and self._all(x == y):
                 return False
 
             comparer = self._lookup(x, y)

--- a/testfixtures/tests/test_compare.py
+++ b/testfixtures/tests/test_compare.py
@@ -102,6 +102,12 @@ class TestCompare(CompareHelper, TestCase):
     def test_different_with_labels(self):
         self.check_raises(1, 2, '1 (expected) != 2 (actual)',
                           x_label='expected', y_label='actual')
+    
+    def test_multi_bool_same(self):
+        compare(MultiBooleanClass(1, 2), MultiBooleanClass(1,2))
+    
+    def test_multi_bool_different(self):
+        self.check_raises(MultiBooleanClass(2, 2), MultiBooleanClass(1,2), "MultiBooleanClass not as expected:\n\nattributes same:\n['b']\n\nattributes differ:\n'a': 2 != 1")
 
     def test_string_same(self):
         compare('x', 'x')
@@ -2008,3 +2014,14 @@ class TestBaseClasses(CompareHelper):
             "attributes differ:\n"
             "'thing': 1 != 2"
         ))
+
+class MultiBooleanClass:
+    def __init__(self, a, b):
+        self.a = a
+        self.b = b
+    
+    def __eq__(self, other):
+        if isinstance(other, MultiBooleanClass):
+            return [other.a == self.a, other.b == self.b]
+        else:
+            return [False, False]

--- a/testfixtures/tests/test_compare.py
+++ b/testfixtures/tests/test_compare.py
@@ -109,6 +109,9 @@ class TestCompare(CompareHelper, TestCase):
     def test_multi_bool_different(self):
         self.check_raises(MultiBooleanClass(2, 2), MultiBooleanClass(1,2), "MultiBooleanClass not as expected:\n\nattributes same:\n['b']\n\nattributes differ:\n'a': 2 != 1")
 
+    def test_multi_bool_different_classes(self):
+        self.check_raises(MultiBooleanClass(2, 2), [1,2], "<testfixtures.tests.test_compare.MultiBooleanClass object at ...> != [1, 2]")
+
     def test_string_same(self):
         compare('x', 'x')
 
@@ -2025,3 +2028,9 @@ class MultiBooleanClass:
             return [other.a == self.a, other.b == self.b]
         else:
             return [False, False]
+
+    def __ne__(self, other):
+        if isinstance(other, MultiBooleanClass):
+            return [other.a == self.a, other.b == self.b]
+        else:
+            return [True, True]


### PR DESCRIPTION
Fixes the issue that the comparison method crashes even before considering custom comparers on comparing elements that return a list of booleans instead of a single boolean.

This can happen with e.g. Pandas, NumPy and GeoPandas objects.