### PR TITLE
fix deprecation warning about invalid escape sequence

### DIFF
--- a/testfixtures/comparison.py
+++ b/testfixtures/comparison.py
@@ -305,7 +305,8 @@ def compare_set(x, y, context):
             ))
     return '\n'.join(lines)+'\n'
 
-trailing_whitespace_re = compile('\s+$', MULTILINE)
+
+trailing_whitespace_re = compile(r'\s+$', MULTILINE)
 
 
 def strip_blank_lines(text):


### PR DESCRIPTION
comparison.py:308: DeprecationWarning: invalid escape sequence \s