### PR TITLE
MappingComparison return type

### DIFF
--- a/testfixtures/comparison.py
+++ b/testfixtures/comparison.py
@@ -1080,6 +1080,7 @@ class MappingComparison(StatefulComparison):
             self.failed = '\n\n'.join(message)
 
             return True
+        return False
 
 
 class StringComparison:

--- a/testfixtures/tests/test_mappingcomparison.py
+++ b/testfixtures/tests/test_mappingcomparison.py
@@ -304,3 +304,8 @@ class TestMappingComparison(object):
         m = MappingComparison(partial=True)
         assert m != []
         check_repr(m, '<MappingComparison(ordered=False, partial=True)(failed)>bad type</>')
+
+    def test_boolean_return(self):
+        m = MappingComparison({'k': 'v'})
+        result = m != {'k': 'v'}
+        assert isinstance(result, bool)


### PR DESCRIPTION
`MappingComparison.__ne__` should return boolean result, not `None`