### PR TITLE
tests: fix with Python 3.10 (changed exception messages)

### DIFF
--- a/testfixtures/compat.py
+++ b/testfixtures/compat.py
@@ -5,6 +5,7 @@ PY_VERSION = sys.version_info[:2]
 
 PY_36_PLUS = PY_VERSION >= (3, 6)
 PY_37_PLUS = PY_VERSION >= (3, 7)
+PY_310_PLUS = PY_VERSION >= (3, 10)
 
 
 if PY_VERSION > (3, 0):

--- a/testfixtures/tests/test_popen.py
+++ b/testfixtures/tests/test_popen.py
@@ -6,7 +6,7 @@ from testfixtures.mock import call
 from testfixtures import ShouldRaise, compare, Replacer
 
 from testfixtures.popen import MockPopen, PopenBehaviour
-from testfixtures.compat import BytesLiteral, PY2
+from testfixtures.compat import BytesLiteral, PY2, PY_310_PLUS
 
 import signal
 
@@ -471,10 +471,11 @@ class Tests(TestCase):
         ], Popen.mock.method_calls)
 
     def test_invalid_parameters(self):
+        message = "__init__() got an unexpected keyword argument 'foo'"
+        if PY_310_PLUS:
+            message = "MockPopenInstance." + message
         Popen = MockPopen()
-        with ShouldRaise(TypeError(
-                "__init__() got an unexpected keyword argument 'foo'"
-        )):
+        with ShouldRaise(TypeError(message)):
             Popen(foo='bar')
 
     def test_invalid_method_or_attr(self):
@@ -492,39 +493,43 @@ class Tests(TestCase):
             process.foo
 
     def test_invalid_communicate_call(self):
+        message = "communicate() got an unexpected keyword argument 'foo'"
+        if PY_310_PLUS:
+            message = "MockPopenInstance." + message
         Popen = MockPopen()
         Popen.set_command('bar')
         process = Popen('bar')
-        with ShouldRaise(TypeError(
-                "communicate() got an unexpected keyword argument 'foo'"
-        )):
+        with ShouldRaise(TypeError(message)):
             process.communicate(foo='bar')
 
     def test_invalid_wait_call(self):
+        message = "wait() got an unexpected keyword argument 'foo'"
+        if PY_310_PLUS:
+            message = "MockPopenInstance." + message
         Popen = MockPopen()
         Popen.set_command('bar')
         process = Popen('bar')
-        with ShouldRaise(TypeError(
-                "wait() got an unexpected keyword argument 'foo'"
-        )):
+        with ShouldRaise(TypeError(message)):
             process.wait(foo='bar')
 
     def test_invalid_send_signal(self):
+        message = "send_signal() got an unexpected keyword argument 'foo'"
+        if PY_310_PLUS:
+            message = "MockPopenInstance." + message
         Popen = MockPopen()
         Popen.set_command('bar')
         process = Popen('bar')
-        with ShouldRaise(TypeError(
-                "send_signal() got an unexpected keyword argument 'foo'"
-        )):
+        with ShouldRaise(TypeError(message)):
             process.send_signal(foo='bar')
 
     def test_invalid_terminate(self):
+        message = "terminate() got an unexpected keyword argument 'foo'"
+        if PY_310_PLUS:
+            message = "MockPopenInstance." + message
         Popen = MockPopen()
         Popen.set_command('bar')
         process = Popen('bar')
-        with ShouldRaise(TypeError(
-                "terminate() got an unexpected keyword argument 'foo'"
-        )):
+        with ShouldRaise(TypeError(message)):
             process.terminate(foo='bar')
 
     def test_invalid_kill(self):
@@ -535,6 +540,8 @@ class Tests(TestCase):
             text = 'kill() takes exactly 1 argument (2 given)'
         else:
             text = 'kill() takes 1 positional argument but 2 were given'
+            if PY_310_PLUS:
+                text = "MockPopenInstance." + text
         with ShouldRaise(TypeError(text)):
             process.kill('moo')
 
@@ -546,6 +553,8 @@ class Tests(TestCase):
             text = 'poll() takes exactly 1 argument (2 given)'
         else:
             text = 'poll() takes 1 positional argument but 2 were given'
+            if PY_310_PLUS:
+                text = "MockPopenInstance." + text
         with ShouldRaise(TypeError(text)):
             process.poll('moo')
 

--- a/testfixtures/tests/test_replace.py
+++ b/testfixtures/tests/test_replace.py
@@ -13,7 +13,7 @@ import os
 
 from testfixtures.tests import sample1
 from testfixtures.tests import sample2
-from ..compat import PY3
+from ..compat import PY3, PY_310_PLUS
 
 from warnings import catch_warnings
 
@@ -259,19 +259,25 @@ class TestReplace(TestCase):
         self.failIf(hasattr(sample1, 'foo'))
 
     def test_replace_delattr_cant_remove(self):
+        if PY_310_PLUS:
+            message = "cannot set 'today' attribute of " \
+                      "immutable type 'datetime.datetime'"
+        else:
+            message = "can't set attributes of " \
+                      "built-in/extension type 'datetime.datetime'"
         with Replacer() as r:
-            with ShouldRaise(TypeError(
-                "can't set attributes of "
-                "built-in/extension type 'datetime.datetime'"
-                    )):
+            with ShouldRaise(TypeError(message)):
                 r.replace('datetime.datetime.today', not_there)
 
     def test_replace_delattr_cant_remove_not_strict(self):
+        if PY_310_PLUS:
+            message = "cannot set 'today' attribute of " \
+                      "immutable type 'datetime.datetime'"
+        else:
+            message = "can't set attributes of " \
+                      "built-in/extension type 'datetime.datetime'"
         with Replacer() as r:
-            with ShouldRaise(TypeError(
-                "can't set attributes of "
-                "built-in/extension type 'datetime.datetime'"
-                    )):
+            with ShouldRaise(TypeError(message)):
                 r.replace('datetime.datetime.today', not_there, strict=False)
 
     def test_replace_dict_remove_key(self):


### PR DESCRIPTION
Hi,
Tests need a few small adjustments to pass with Python 3.10.

I guess you could add Python 3.10 it to your CI (and make it non-fatal) but I don't know how Circle CI works so I did not attempt to do it.