### PR TITLE
Fix deprecated aliases for Python 3.11 compatibility.

### DIFF
--- a/testfixtures/tests/test_comparison.py
+++ b/testfixtures/tests/test_comparison.py
@@ -681,7 +681,7 @@ class TestC(TestCase):
         try:
             C('testfixtures.bonkers')
         except Exception as e:
-            self.failUnless(isinstance(e, AttributeError))
+            self.assertTrue(isinstance(e, AttributeError))
             self.assertEqual(
                 e.args,
                 ("'testfixtures.bonkers' could not be resolved", )

--- a/testfixtures/tests/test_date.py
+++ b/testfixtures/tests/test_date.py
@@ -66,7 +66,7 @@ class TestDate(TestCase):
         compare(t(2002, 1, 2), d(2002, 1, 2))
         from datetime import date
         dt = date(2003, 2, 1)
-        self.failIf(dt.__class__ is d)
+        self.assertFalse(dt.__class__ is d)
         compare(dt, d(2003, 2, 1))
 
     def test_gotcha_import(self):
@@ -214,10 +214,10 @@ class TestDate(TestCase):
         to_check.append(date.today())
 
         for inst in to_check:
-            self.failUnless(isinstance(inst, date), inst)
-            self.failUnless(inst.__class__ is date, inst)
-            self.failUnless(isinstance(inst, d), inst)
-            self.failIf(inst.__class__ is d, inst)
+            self.assertTrue(isinstance(inst, date), inst)
+            self.assertTrue(inst.__class__ is date, inst)
+            self.assertTrue(isinstance(inst, d), inst)
+            self.assertFalse(inst.__class__ is d, inst)
 
     @replace('datetime.date', test_date())
     def test_isinstance_default(self):
@@ -242,10 +242,10 @@ class TestDate(TestCase):
         to_check.append(date.today())
 
         for inst in to_check:
-            self.failIf(isinstance(inst, date), inst)
-            self.failIf(inst.__class__ is date, inst)
-            self.failUnless(isinstance(inst, d), inst)
-            self.failUnless(inst.__class__ is d, inst)
+            self.assertFalse(isinstance(inst, date), inst)
+            self.assertFalse(inst.__class__ is date, inst)
+            self.assertTrue(isinstance(inst, d), inst)
+            self.assertTrue(inst.__class__ is d, inst)
 
     def test_tick_when_static(self):
         date = test_date(delta=0)

--- a/testfixtures/tests/test_datetime.py
+++ b/testfixtures/tests/test_datetime.py
@@ -136,7 +136,7 @@ class TestDateTime(TestCase):
         compare(t(2002, 1, 2, 3, 4, 5), d(2002, 1, 2, 3, 4, 5))
         from datetime import datetime
         dt = datetime(2001, 1, 1, 1, 0, 0)
-        self.failIf(dt.__class__ is d)
+        self.assertFalse(dt.__class__ is d)
         compare(dt, d(2001, 1, 1, 1, 0, 0))
 
     def test_date_return_type(self):
@@ -146,7 +146,7 @@ class TestDateTime(TestCase):
             dt = datetime(2001, 1, 1, 1, 0, 0)
             d = dt.date()
             compare(d, date(2001, 1, 1))
-            self.failUnless(d.__class__ is date)
+            self.assertTrue(d.__class__ is date)
 
     def test_date_return_type_picky(self):
         # type checking is a bitch :-/
@@ -159,7 +159,7 @@ class TestDateTime(TestCase):
             dt = datetime(2010, 8, 26, 14, 33, 13)
             d = dt.date()
             compare(d, date_type(2010, 8, 26))
-            self.failUnless(d.__class__ is date_type)
+            self.assertTrue(d.__class__ is date_type)
 
     # if you have an embedded `now` as above, *and* you need to supply
     # a list of required datetimes, then it's often simplest just to
@@ -328,10 +328,10 @@ class TestDateTime(TestCase):
         to_check.append(datetime.now(SampleTZInfo()))
 
         for inst in to_check:
-            self.failUnless(isinstance(inst, datetime), inst)
-            self.failUnless(inst.__class__ is datetime, inst)
-            self.failUnless(isinstance(inst, d), inst)
-            self.failIf(inst.__class__ is d, inst)
+            self.assertTrue(isinstance(inst, datetime), inst)
+            self.assertTrue(inst.__class__ is datetime, inst)
+            self.assertTrue(isinstance(inst, d), inst)
+            self.assertFalse(inst.__class__ is d, inst)
 
     @replace('datetime.datetime', test_datetime())
     def test_isinstance_default(self):
@@ -360,10 +360,10 @@ class TestDateTime(TestCase):
         to_check.append(datetime.now(SampleTZInfo()))
 
         for inst in to_check:
-            self.failIf(isinstance(inst, datetime), inst)
-            self.failIf(inst.__class__ is datetime, inst)
-            self.failUnless(isinstance(inst, d), inst)
-            self.failUnless(inst.__class__ is d, inst)
+            self.assertFalse(isinstance(inst, datetime), inst)
+            self.assertFalse(inst.__class__ is datetime, inst)
+            self.assertTrue(isinstance(inst, d), inst)
+            self.assertTrue(inst.__class__ is d, inst)
 
     def test_subsecond_deltas(self):
         datetime = test_datetime(delta=0.5)

--- a/testfixtures/tests/test_generator.py
+++ b/testfixtures/tests/test_generator.py
@@ -9,11 +9,11 @@ class TestG(TestCase):
 
     def test_example(self):
         g = generator(1, 2, 3)
-        self.failUnless(isinstance(g, GeneratorType))
+        self.assertTrue(isinstance(g, GeneratorType))
         self.assertEqual(tuple(g), (1, 2, 3))
 
     def test_from_sequence(self):
         s = (1, 2, 3)
         g = generator(*s)
-        self.failUnless(isinstance(g, GeneratorType))
+        self.assertTrue(isinstance(g, GeneratorType))
         self.assertEqual(tuple(g), (1, 2, 3))

--- a/testfixtures/tests/test_log_capture.py
+++ b/testfixtures/tests/test_log_capture.py
@@ -98,7 +98,7 @@ class TestLog_Capture(TestCase):
     def test_decorator_returns_logcapture(self, l):
         # check for what we get, so we only have to write
         # tests in test_logcapture.py
-        self.failUnless(isinstance(l, LogCapture))
+        self.assertTrue(isinstance(l, LogCapture))
 
     def test_remove_existing_handlers(self):
         logger = getLogger()

--- a/testfixtures/tests/test_replace.py
+++ b/testfixtures/tests/test_replace.py
@@ -44,21 +44,21 @@ class TestReplace(TestCase):
         class ReplacementX(sample1.X):
             pass
 
-        self.failIf(OriginalX is ReplacementX)
-        self.failUnless(isinstance(sample1.X(), OriginalX))
+        self.assertFalse(OriginalX is ReplacementX)
+        self.assertTrue(isinstance(sample1.X(), OriginalX))
 
         @replace('testfixtures.tests.sample1.X', ReplacementX)
         def test_something():
-            self.failIf(OriginalX is ReplacementX)
-            self.failUnless(isinstance(sample1.X(), ReplacementX))
+            self.assertFalse(OriginalX is ReplacementX)
+            self.assertTrue(isinstance(sample1.X(), ReplacementX))
 
-        self.failIf(OriginalX is ReplacementX)
-        self.failUnless(isinstance(sample1.X(), OriginalX))
+        self.assertFalse(OriginalX is ReplacementX)
+        self.assertTrue(isinstance(sample1.X(), OriginalX))
 
         test_something()
 
-        self.failIf(OriginalX is ReplacementX)
-        self.failUnless(isinstance(sample1.X(), OriginalX))
+        self.assertFalse(OriginalX is ReplacementX)
+        self.assertTrue(isinstance(sample1.X(), OriginalX))
 
     def test_method(self):
 
@@ -69,7 +69,7 @@ class TestReplace(TestCase):
 
         @replace('testfixtures.tests.sample1.X.y', test_y)
         def test_something():
-            self.failUnless(isinstance(sample1.X().y(), sample1.X))
+            self.assertTrue(isinstance(sample1.X().y(), sample1.X))
 
         compare(sample1.X().y(), 'original y')
 
@@ -170,8 +170,8 @@ class TestReplace(TestCase):
 
         @replace('testfixtures.tests.sample1.z', o)
         def test_something(r):
-            self.failUnless(r is o)
-            self.failUnless(sample1.z is o)
+            self.assertTrue(r is o)
+            self.assertTrue(sample1.z is o)
 
         test_something()
 
@@ -192,8 +192,8 @@ class TestReplace(TestCase):
 
         @replace('testfixtures.tests.sample1.bad', o, strict=False)
         def test_something(r):
-            self.failUnless(r is o)
-            self.failUnless(sample1.bad is o)
+            self.assertTrue(r is o)
+            self.assertTrue(sample1.bad is o)
 
         test_something()
 
@@ -206,12 +206,12 @@ class TestReplace(TestCase):
 
         @replace('testfixtures.tests.sample1.someDict.key', replacement)
         def test_something(obj):
-            self.failUnless(obj is replacement)
-            self.failUnless(someDict['key'] is replacement)
+            self.assertTrue(obj is replacement)
+            self.assertTrue(someDict['key'] is replacement)
 
         test_something()
 
-        self.failUnless(someDict['key'] is original)
+        self.assertTrue(someDict['key'] is original)
 
     def test_replace_delattr(self):
 
@@ -219,7 +219,7 @@ class TestReplace(TestCase):
 
         @replace('testfixtures.tests.sample1.someDict', not_there)
         def test_something(obj):
-            self.failIf(hasattr(sample1, 'someDict'))
+            self.assertFalse(hasattr(sample1, 'someDict'))
 
         test_something()
 
@@ -242,7 +242,7 @@ class TestReplace(TestCase):
         @replace('testfixtures.tests.sample1.foo',
                  not_there, strict=False)
         def test_something(obj):
-            self.failIf(hasattr(sample1, 'foo'))
+            self.assertFalse(hasattr(sample1, 'foo'))
 
         test_something()
 
@@ -256,7 +256,7 @@ class TestReplace(TestCase):
             sample1.foo = 'bar'
 
         test_something()
-        self.failIf(hasattr(sample1, 'foo'))
+        self.assertFalse(hasattr(sample1, 'foo'))
 
     def test_replace_delattr_cant_remove(self):
         with Replacer() as r:
@@ -280,7 +280,7 @@ class TestReplace(TestCase):
 
         @replace('testfixtures.tests.sample1.someDict.key', not_there)
         def test_something(obj):
-            self.failIf('key' in someDict)
+            self.assertFalse('key' in someDict)
 
         test_something()
 
@@ -292,7 +292,7 @@ class TestReplace(TestCase):
 
         @replace('testfixtures.tests.sample1.someDict.badkey', not_there)
         def test_something(obj):
-            self.failIf('badkey' in someDict)  # pragma: no cover
+            self.assertFalse('badkey' in someDict)  # pragma: no cover
 
         with ShouldRaise(AttributeError("Original 'badkey' not found")):
             test_something()
@@ -306,7 +306,7 @@ class TestReplace(TestCase):
         @replace('testfixtures.tests.sample1.someDict.badkey',
                  not_there, strict=False)
         def test_something(obj):
-            self.failIf('badkey' in someDict)
+            self.assertFalse('badkey' in someDict)
 
         test_something()
 
@@ -335,8 +335,8 @@ class TestReplace(TestCase):
                  replacement,
                  strict=False)
         def test_something(obj):
-            self.failUnless(obj is replacement)
-            self.failUnless(someDict['key2'] is replacement)
+            self.assertTrue(obj is replacement)
+            self.assertTrue(someDict['key2'] is replacement)
 
         test_something()
 
@@ -364,14 +364,14 @@ class TestReplace(TestCase):
         @replace('testfixtures.tests.sample1.someDict.complex_key.1',
                  replacement)
         def test_something(obj):
-            self.failUnless(obj is replacement)
+            self.assertTrue(obj is replacement)
             self.assertEqual(someDict['complex_key'], [1, obj, 3])
 
         test_something()
 
         self.assertEqual(someDict['complex_key'], [1, 2, 3])
 
-        self.failUnless(original is someDict['complex_key'][1])
+        self.assertTrue(original is someDict['complex_key'][1])
 
     def test_replacer_del(self):
         r = Replacer()

--- a/testfixtures/tests/test_stringcomparison.py
+++ b/testfixtures/tests/test_stringcomparison.py
@@ -8,26 +8,26 @@ from unittest import TestCase
 class Tests(TestCase):
 
     def test_equal_yes(self):
-        self.failUnless('on 40220' == S('on \d+'))
+        self.assertTrue('on 40220' == S('on \d+'))
 
     def test_equal_no(self):
-        self.failIf('on xxx' == S('on \d+'))
+        self.assertFalse('on xxx' == S('on \d+'))
 
     def test_not_equal_yes(self):
-        self.failIf('on 40220' != S('on \d+'))
+        self.assertFalse('on 40220' != S('on \d+'))
 
     def test_not_equal_no(self):
-        self.failUnless('on xxx' != S('on \d+'))
+        self.assertTrue('on xxx' != S('on \d+'))
 
     def test_comp_in_sequence(self):
-        self.failUnless((
+        self.assertTrue((
             1, 2, 'on 40220'
             ) == (
             1, 2, S('on \d+')
             ))
 
     def test_not_string(self):
-        self.failIf(40220 == S('on \d+'))
+        self.assertFalse(40220 == S('on \d+'))
 
     def test_repr(self):
         compare('<S:on \\d+>',
@@ -48,10 +48,10 @@ class Tests(TestCase):
         # cmp no longer exists in Python 3!
 
         def test_cmp_yes(self):
-            self.failIf(cmp(S('on \d+'), 'on 4040'))
+            self.assertFalse(cmp(S('on \d+'), 'on 4040'))
 
         def test_cmp_no(self):
-            self.failUnless(cmp(S('on \d+'), 'on xx'))
+            self.assertTrue(cmp(S('on \d+'), 'on xx'))
 
     def test_flags_argument(self):
         compare(S(".*bar", re.DOTALL), actual="foo\nbar")

--- a/testfixtures/tests/test_tempdir.py
+++ b/testfixtures/tests/test_tempdir.py
@@ -62,7 +62,7 @@ class TestTempDir(TestCase):
             m.return_value = d
             r.replace('testfixtures.tempdirectory.mkdtemp', m)
 
-            self.failUnless(os.path.exists(d))
+            self.assertTrue(os.path.exists(d))
 
             self.assertFalse(m.called)
 
@@ -77,7 +77,7 @@ class TestTempDir(TestCase):
             test_method()
 
             self.assertTrue(m.called)
-            self.failIf(os.path.exists(d))
+            self.assertFalse(os.path.exists(d))
 
         finally:
             r.restore()
@@ -93,7 +93,7 @@ class TestTempDir(TestCase):
     def test_decorator_returns_tempdirectory(self, d):
         # check for what we get, so we only have to write
         # tests in test_tempdirectory.py
-        self.failUnless(isinstance(d, TempDirectory))
+        self.assertTrue(isinstance(d, TempDirectory))
 
     def test_dont_create_or_cleanup_with_path(self):
         with Replacer() as r:

--- a/testfixtures/tests/test_tempdirectory.py
+++ b/testfixtures/tests/test_tempdirectory.py
@@ -127,7 +127,7 @@ class TempDirectoryTests(TestCase):
         rmtree(d)
         td = TempDirectory(path=d)
         self.assertEqual(d, td.path)
-        self.failIf(os.path.exists(d))
+        self.assertFalse(os.path.exists(d))
 
     def test_deprecated_check(self):
         with TempDirectory() as d:


### PR DESCRIPTION
Fixes #162 . The changes are mostly straightforward find and replace.

```
$ perl -pi -e 's/failIf/assertFalse/g' **/*py
$ perl -pi -e 's/failUnless/assertTrue/g' **/*py
```