### PR TITLE
Update to Sybil 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ optional = [
     'zope.component',
     'django<2;python_version<"3"',
     'django;python_version>="3"',
-    'sybil<3',
+    'sybil>=3',
     'twisted'
 ]
 

--- a/testfixtures/tests/conftest.py
+++ b/testfixtures/tests/conftest.py
@@ -1,6 +1,6 @@
 from sybil import Sybil
 from sybil.parsers.doctest import  DocTestParser
-from sybil.parsers.codeblock import CodeBlockParser
+from sybil.parsers.codeblock import PythonCodeBlockParser
 from sybil.parsers.capture import parse_captures
 
 from testfixtures import TempDirectory
@@ -18,7 +18,7 @@ def sybil_teardown(namespace):
 pytest_collect_file = Sybil(
     parsers=[
         DocTestParser(),
-        CodeBlockParser(),
+        PythonCodeBlockParser(),
         parse_captures,
         FileParser('tempdir'),
     ],


### PR DESCRIPTION
Hi, we are trying to enable packages for Python 3.10 in openSUSE Tumleweed. We need sybil 3 for that, but not being able to update testfixtures blocks it.

AFAICT the rename of the CodeBlockParser was the only relevant change.