### PR TITLE
Use new sybil 3 name for codeblock parser if available

### DIFF
--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,8 +1,16 @@
 from doctest import REPORT_NDIFF, ELLIPSIS
 
 from sybil import Sybil
-from sybil.parsers.doctest import DocTestParser, FIX_BYTE_UNICODE_REPR
-from sybil.parsers.codeblock import CodeBlockParser
+from sybil.parsers.doctest import DocTestParser
+try:
+    from sybil.parsers.doctest import FIX_BYTE_UNICODE_REPR
+except ImportError:
+    # sybil 3 removed the optionflag
+    FIX_BYTE_UNICODE_REPR = 0
+try:
+    from sybil.parsers.codeblock import PythonCodeBlockParser
+except ImportError:
+    from sybil.parsers.codeblock import CodeBlockParser as PythonCodeBlockParser
 from sybil.parsers.capture import parse_captures
 
 from testfixtures.compat import PY3
@@ -13,7 +21,7 @@ if PY3:
     pytest_collect_file = Sybil(
         parsers=[
             DocTestParser(optionflags=REPORT_NDIFF|ELLIPSIS|FIX_BYTE_UNICODE_REPR),
-            CodeBlockParser(['print_function']),
+            PythonCodeBlockParser(['print_function']),
             parse_captures,
             FileParser('tempdir'),
         ],

--- a/docs/django.txt
+++ b/docs/django.txt
@@ -23,7 +23,7 @@ Traceback (most recent call last):
 AssertionError: SampleModel not as expected:
 <BLANKLINE>
 same:
-[u'id']
+['id']
 <BLANKLINE>
 values differ:
 'value': 1 != 2
@@ -38,7 +38,7 @@ Traceback (most recent call last):
 AssertionError: SampleModel not as expected:
 <BLANKLINE>
 same:
-[u'id']
+['id']
 <BLANKLINE>
 values differ:
 'value': 1 != 2
@@ -70,7 +70,7 @@ Traceback (most recent call last):
 AssertionError: SampleModel not as expected:
 <BLANKLINE>
 same:
-['created', u'id', 'value']
+['created', 'id', 'value']
 <BLANKLINE>
 values differ:
 'not_editable': 1 != 2

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ optional = [
     'zope.component',
     'django<2;python_version<"3"',
     'django;python_version>="3"',
-    'sybil<3',
+    'sybil',
     'twisted'
 ]
 

--- a/testfixtures/tests/conftest.py
+++ b/testfixtures/tests/conftest.py
@@ -1,6 +1,10 @@
 from sybil import Sybil
 from sybil.parsers.doctest import  DocTestParser
-from sybil.parsers.codeblock import CodeBlockParser
+try:
+    from sybil.parsers.codeblock import PythonCodeBlockParser
+except ImportError:
+    # sybil < 3 has it under the old name
+    from sybil.parsers.codeblock import CodeBlockParser as PythonCodeBlockParser
 from sybil.parsers.capture import parse_captures
 
 from testfixtures import TempDirectory
@@ -18,7 +22,7 @@ def sybil_teardown(namespace):
 pytest_collect_file = Sybil(
     parsers=[
         DocTestParser(),
-        CodeBlockParser(),
+        PythonCodeBlockParser(),
         parse_captures,
         FileParser('tempdir'),
     ],


### PR DESCRIPTION
Hi, we are trying to enable packages for Python 3.10 in openSUSE Tumleweed. We need sybil 3 for that, but not being able to update testfixtures blocks it.

~AFAICT the rename of the CodeBlockParser was the only relevant change.~ Edit: Did not check the doctests. My bad.

New version of #166: Also allow older version for Python 2 support.