### PR TITLE
Fix tuple of strings type hints

### DIFF
--- a/testfixtures/logcapture.py
+++ b/testfixtures/logcapture.py
@@ -64,7 +64,7 @@ class LogCapture(logging.Handler):
 
     def __init__(
             self,
-            names: Union[str, Tuple[str]] = None,
+            names: Union[str, Tuple[str, ...]] = None,
             install: bool = True,
             level: int = 1,
             propagate: bool = None,

--- a/testfixtures/tempdirectory.py
+++ b/testfixtures/tempdirectory.py
@@ -13,7 +13,7 @@ from testfixtures.utils import wrap
 from .rmtree import rmtree
 
 
-PathStrings = Union[str, Tuple[str]]
+PathStrings = Union[str, Tuple[str, ...]]
 
 
 if TYPE_CHECKING:


### PR DESCRIPTION
I found two places where type hints declare one item tuple instead of arbitrary-length tuple of strings (as indicated by docstring).