### PR TITLE
Work for replacing where the original is somewhere interesting

### DIFF
--- a/testfixtures/replace.py
+++ b/testfixtures/replace.py
@@ -109,8 +109,22 @@ class Replacer:
 
         if resolved.setter is None:
             raise ValueError('target must contain at least one dot!')
+
         if resolved.found is not_there and strict:
             raise AttributeError('Original %r not found' % resolved.name)
+
+        if (
+                hasattr(resolved.container, '__dict__') and
+                resolved.setter is setattr and
+                resolved.name not in resolved.container.__dict__
+        ):
+            if strict:
+                raise AttributeError(
+                    f'{resolved.container!r} has __dict__ but {resolved.name!r} is not in it'
+                )
+            else:
+                resolved.found = not_there
+
 
         replacement_to_use = replacement
 

--- a/testfixtures/replace.py
+++ b/testfixtures/replace.py
@@ -3,7 +3,7 @@ from contextlib import contextmanager
 from functools import partial
 from gc import get_referrers, get_referents
 from operator import setitem, getitem
-from types import ModuleType
+from types import ModuleType, MethodType
 from typing import Any, TypeVar, Callable, Dict, Tuple
 
 from testfixtures.resolve import resolve, not_there, Resolved, classmethod_type, class_type, Setter
@@ -90,6 +90,11 @@ class Replacer:
 
             if strict and not (found is not_there or target is container):
                 if found is not target:
+                    if isinstance(found, MethodType):
+                        raise TypeError(
+                            'Cannot replace methods on instances with strict=True, '
+                            'replace on class or use strict=False'
+                        )
                     raise AssertionError(
                         f'{accessor} of {name!r} from {container!r} gave {found!r}, '
                         f'expected {target}'

--- a/testfixtures/replace.py
+++ b/testfixtures/replace.py
@@ -202,8 +202,8 @@ class Replacer:
         Restore all the original objects that have been replaced by
         calls to the :meth:`replace` method of this :class:`Replacer`.
         """
-        for id_, (target, original) in tuple(self.originals.items()):
-            self._replace(original, original.found)
+        for id_, (target, resolved) in tuple(self.originals.items()):
+            self._replace(resolved, resolved.found)
             del self.originals[id_]
 
     def __enter__(self):

--- a/testfixtures/replace.py
+++ b/testfixtures/replace.py
@@ -89,9 +89,11 @@ class Replacer:
                         found = not_there
 
             if strict and not (found is not_there or target is container):
-                expected = accessor(container, name)
-                if target is not expected:
-                    raise AssertionError(f'{name!r} resolved to {found}, expected {target}')
+                if found is not target:
+                    raise AssertionError(
+                        f'{accessor} of {name!r} from {container!r} gave {found!r}, '
+                        f'expected {target}'
+                    )
 
             resolved = Resolved(
                 container,

--- a/testfixtures/replace.py
+++ b/testfixtures/replace.py
@@ -66,7 +66,6 @@ class Replacer:
         if isinstance(target, str) and not name:
             resolved = resolve(target, container, sep)
         else:
-            found = not_there
             if container is None:
                 container = target
 
@@ -79,7 +78,7 @@ class Replacer:
                         accessor = getitem
                         found = accessor(container, name)
                     except KeyError:
-                        pass
+                        found = not_there
                     except TypeError:
                         accessor = getattr
                         found = accessor(container, name, not_there)
@@ -87,7 +86,7 @@ class Replacer:
                     try:
                         found = accessor(container, name)
                     except (KeyError, AttributeError):
-                        pass
+                        found = not_there
 
             if strict and not (found is not_there or target is container):
                 expected = accessor(container, name)

--- a/testfixtures/tests/test_replace.py
+++ b/testfixtures/tests/test_replace.py
@@ -572,10 +572,13 @@ class TestReplace(TestCase):
                 return 2
 
         sample_obj = SampleClass()
+        s_repr = repr(SampleClass)
         a_repr = repr(SampleClass.a)
         b_repr = repr(SampleClass.b)
         replacer = Replacer()
-        with ShouldRaise(AssertionError(f"'b' resolved to {b_repr}, expected {a_repr}")):
+        with ShouldRaise(AssertionError(
+                f"<built-in function getattr> of 'b' from {s_repr} gave {b_repr}, expected {a_repr}"
+        )):
             replacer(SampleClass.a, lambda self: 3,
                      container=SampleClass, name='b', accessor=getattr)
 


### PR DESCRIPTION
Replacing a method on a subclass rather than the base class ends up leaving the replacement there after restore.
Digging in to this uncovered a bunch of other sadness, so this deals with all of that.