### PR TITLE
Support Python 3.13's AttributeError changes

### DIFF
--- a/testfixtures/tests/test_replace.py
+++ b/testfixtures/tests/test_replace.py
@@ -15,6 +15,7 @@ from testfixtures import (
 from unittest import TestCase
 
 import os
+import sys
 
 from testfixtures.mock import Mock
 from testfixtures.tests import sample1, sample3
@@ -1362,7 +1363,10 @@ class TestReplaceWithInterestingOriginsNotStrict(TestReplaceWithInterestingOrigi
         obj = OriginE()
         assert not hasattr(obj, '__dict__')
         replace_ = Replacer()
-        with ShouldRaise(AttributeError("'OriginE' object has no attribute 'bad'")):
+        msg = "'OriginE' object has no attribute 'bad'"
+        if sys.version_info >= (3, 13):
+            msg += " and no __dict__ for setting new attributes"
+        with ShouldRaise(AttributeError(msg)):
             replace_(obj, name='bad', replacement=42, strict=self.strict)
 
     def test_method_on_instance_of_slotted_subclass(self):


### PR DESCRIPTION
Python 3.13 has changed the message that is raised with an AttributeError to provide a hint on how to help avoid it -- but this breaks a test case. Support both the old and the new message.