### PR TITLE
Initial steps towards full typing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ common: &common
     - python/pip-run-tests:
         matrix:
           parameters:
-            image:
+            image: &python_versions
               - cimg/python:3.11
               - cimg/python:3.12
               - cimg/python:3.13
@@ -42,6 +42,12 @@ common: &common
         name: django-latest
         image: cimg/python:3.11
         extra_packages: "django"
+
+    - python/typing:
+        packages: testfixtures
+        matrix:
+          parameters:
+            image: *python_versions
 
     - python/coverage:
         name: coverage
@@ -90,6 +96,7 @@ common: &common
         name: release
         config: .carthorse.yml
         requires:
+          - python/typing
           - check-package-python
           - check-package-python-mock
           - check-package-python-django

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,6 @@
+[mypy]
+plugins =
+    mypy_django_plugin.main
+
+[mypy.plugins.django-stubs]
+django_settings_module = "testfixtures.tests.test_django.settings"

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,14 @@
 [mypy]
+disable_error_code = annotation-unchecked
 plugins =
     mypy_django_plugin.main
 
 [mypy.plugins.django-stubs]
 django_settings_module = "testfixtures.tests.test_django.settings"
+
+[mypy-constantly.*]
+ignore_missing_imports = True
+
+[mypy-guppy]
+# guppy isn't actually ever installed:
+ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,8 @@ setup(
     include_package_data=True,
     python_requires=">=3.11",
     extras_require=dict(
-        test=['mypy',
+        test=['django-stubs',
+              'mypy',
               'pytest>=7.1',
               'pytest-cov',
               'pytest-django',

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
               'pytest>=7.1',
               'pytest-cov',
               'pytest-django',
+              'types-mock',
               ]+optional,
         docs=['sphinx', 'furo']+optional,
         build=['setuptools-git', 'wheel', 'twine']

--- a/testfixtures/__init__.py
+++ b/testfixtures/__init__.py
@@ -36,8 +36,8 @@ from testfixtures.utils import wrap, generator
 
 # backwards compatibility for the old names
 test_datetime = mock_datetime
-test_datetime.__test__ = False
+test_datetime.__test__ = False  # type: ignore[attr-defined]
 test_date = mock_date
-test_date.__test__ = False
+test_date.__test__ = False  # type: ignore[attr-defined]
 test_time = mock_time
-test_time.__test__ = False
+test_time.__test__ = False  # type: ignore[attr-defined]

--- a/testfixtures/comparison.py
+++ b/testfixtures/comparison.py
@@ -8,7 +8,7 @@ from operator import __or__
 from pathlib import Path
 from pprint import pformat
 from typing import (
-    Dict, Any, Optional, Sequence, Generator, TypeVar, List, Mapping, Pattern, Union,
+    Dict, Any, Sequence, Generator, TypeVar, List, Mapping, Pattern, Union,
     Callable, Iterable
 )
 from types import GeneratorType
@@ -67,7 +67,7 @@ def compare_simple(x, y, context: 'CompareContext'):
         return context.label('x', repr_x) + ' != ' + context.label('y', repr_y)
 
 
-def _extract_attrs(obj, ignore: Iterable[str] | None = None) -> Optional[Dict[str, Any]]:
+def _extract_attrs(obj, ignore: Iterable[str] | None = None) -> Dict[str, Any] | None:
     try:
         attrs = vars(obj).copy()
     except TypeError:
@@ -110,7 +110,7 @@ def _attrs_to_ignore(
 
 def compare_object(
         x, y, context: 'CompareContext', ignore_attributes: Iterable[str] = ()
-) -> Optional[str]:
+) -> str | None:
     """
     Compare the two supplied objects based on their type and attributes.
 
@@ -139,7 +139,7 @@ def compare_object(
 
 def compare_exception(
         x: BaseException, y: BaseException, context: 'CompareContext'
-) -> Optional[str]:
+) -> str | None:
     """
     Compare the two supplied exceptions based on their message, type and
     attributes.
@@ -169,7 +169,7 @@ def compare_with_type(x, y, context: 'CompareContext') -> str:
 
 def compare_sequence(
         x: Sequence, y: Sequence, context: 'CompareContext', prefix: bool = True
-) -> Optional[str]:
+) -> str | None:
     """
     Returns a textual description of the differences between the two
     supplied sequences.
@@ -194,7 +194,7 @@ def compare_sequence(
                           )
 
 
-def compare_generator(x: Generator, y: Generator, context: 'CompareContext') -> Optional[str]:
+def compare_generator(x: Generator, y: Generator, context: 'CompareContext') -> str | None:
     """
     Returns a textual description of the differences between the two
     supplied generators.
@@ -212,7 +212,7 @@ def compare_generator(x: Generator, y: Generator, context: 'CompareContext') -> 
     return compare_sequence(x, y, context)
 
 
-def compare_tuple(x: tuple, y: tuple, context: 'CompareContext') -> Optional[str]:
+def compare_tuple(x: tuple, y: tuple, context: 'CompareContext') -> str | None:
     """
     Returns a textual difference between two tuples or
     :func:`collections.namedtuple` instances.
@@ -233,7 +233,7 @@ def compare_tuple(x: tuple, y: tuple, context: 'CompareContext') -> Optional[str
     return compare_sequence(x, y, context)
 
 
-def compare_dict(x: dict, y: dict, context: 'CompareContext') -> Optional[str]:
+def compare_dict(x: dict, y: dict, context: 'CompareContext') -> str | None:
     """
     Returns a textual description of the differences between the two
     supplied dictionaries.
@@ -252,7 +252,7 @@ def _compare_mapping(
         x: Mapping, y: Mapping, context: 'CompareContext', obj_for_class: Any,
         prefix: str = '', breadcrumb: str = '[%r]',
         check_y_not_x: bool = True
-) -> Optional[str]:
+) -> str | None:
 
     x_keys = set(x.keys())
     y_keys = set(y.keys())
@@ -308,7 +308,7 @@ def _compare_mapping(
     return '\n'.join(lines)
 
 
-def compare_set(x: set, y: set, context: 'CompareContext') -> Optional[str]:
+def compare_set(x: set, y: set, context: 'CompareContext') -> str | None:
     """
     Returns a textual description of the differences between the two
     supplied sets.
@@ -399,7 +399,7 @@ def compare_text(x: str, y: str, context: 'CompareContext'):
     return message
 
 
-def compare_bytes(x: bytes, y: bytes, context: 'CompareContext') -> Optional[str]:
+def compare_bytes(x: bytes, y: bytes, context: 'CompareContext') -> str | None:
     if x == y:
         return
     labelled_x = context.label('x', repr(x))
@@ -407,7 +407,7 @@ def compare_bytes(x: bytes, y: bytes, context: 'CompareContext') -> Optional[str
     return '\n%s\n!=\n%s' % (labelled_x, labelled_y)
 
 
-def compare_call(x, y, context: 'CompareContext') -> Optional[str]:
+def compare_call(x, y, context: 'CompareContext') -> str | None:
     if x == y:
         return
 
@@ -439,7 +439,7 @@ def compare_call(x, y, context: 'CompareContext') -> Optional[str]:
     return 'mock.call not as expected:'
 
 
-def compare_partial(x: partial_type, y: partial_type, context: 'CompareContext') -> Optional[str]:
+def compare_partial(x: partial_type, y: partial_type, context: 'CompareContext') -> str | None:
     x_attrs = dict(func=x.func, args=x.args, keywords=x.keywords)
     y_attrs = dict(func=y.func, args=y.args, keywords=y.keywords)
     if x_attrs != y_attrs:
@@ -447,11 +447,11 @@ def compare_partial(x: partial_type, y: partial_type, context: 'CompareContext')
                                 'attributes ', '.%s')
 
 
-def compare_path(x: Path, y: Path, context: 'CompareContext') -> Optional[str]:
+def compare_path(x: Path, y: Path, context: 'CompareContext') -> str | None:
     return compare_text(str(x), str(y), context)
 
 
-def compare_with_fold(x: datetime, y: datetime, context: 'CompareContext') -> Optional[str]:
+def compare_with_fold(x: datetime, y: datetime, context: 'CompareContext') -> str | None:
     if not (x == y and x.fold == y.fold):
         repr_x = repr(x)
         repr_y = repr(y)
@@ -468,7 +468,7 @@ def _short_repr(obj) -> str:
     return repr_
 
 
-Comparer = Callable[[Any, Any, 'CompareContext'], Optional[str]]
+Comparer = Callable[[Any, Any, 'CompareContext'], str | None]
 Registry = Dict[type, Comparer]
 
 _registry: Registry = {
@@ -494,7 +494,7 @@ _registry: Registry = {
 
 def compare_exception_group(
     x: BaseExceptionGroup, y: BaseExceptionGroup, context: 'CompareContext'
-) -> Optional[str]:
+) -> str | None:
     """
     Compare the two supplied exception groups
     """
@@ -553,8 +553,8 @@ class CompareContext:
 
     def __init__(
             self,
-            x_label: Optional[str],
-            y_label: Optional[str],
+            x_label: str | None,
+            y_label: str | None,
             recursive: bool = True,
             strict: bool = False,
             ignore_eq: bool = False,
@@ -651,7 +651,7 @@ class CompareContext:
     def simple_equals(self, x: Any, y: Any) -> bool:
         return not (self.strict or self.ignore_eq) and x == y
 
-    def different(self, x: Any, y: Any, breadcrumb: str) -> Union[bool, Optional[str]]:
+    def different(self, x: Any, y: Any, breadcrumb: str) -> Union[bool, str | None]:
 
         x = self._break_loops(x, breadcrumb)
         y = self._break_loops(y, breadcrumb)
@@ -716,7 +716,7 @@ def compare(
         ignore_eq: bool = False,
         comparers: Registry | None = None,
         **options: Any
-) -> Optional[str]:
+) -> str | None:
     """
     Compare two objects, raising an :class:`AssertionError` if they are not
     the same. The :class:`AssertionError` raised will attempt to provide

--- a/testfixtures/comparison.py
+++ b/testfixtures/comparison.py
@@ -8,7 +8,7 @@ from operator import __or__
 from pathlib import Path
 from pprint import pformat
 from typing import (
-    Dict, Any, Sequence, Generator, TypeVar, List, Mapping, Pattern, Union,
+    Dict, Any, Sequence, Generator, TypeVar, List, Mapping, Pattern,
     Callable, Iterable
 )
 from types import GeneratorType
@@ -651,7 +651,7 @@ class CompareContext:
     def simple_equals(self, x: Any, y: Any) -> bool:
         return not (self.strict or self.ignore_eq) and x == y
 
-    def different(self, x: Any, y: Any, breadcrumb: str) -> Union[bool, str | None]:
+    def different(self, x: Any, y: Any, breadcrumb: str) -> bool | str | None:
 
         x = self._break_loops(x, breadcrumb)
         y = self._break_loops(y, breadcrumb)

--- a/testfixtures/comparison.py
+++ b/testfixtures/comparison.py
@@ -67,7 +67,7 @@ def compare_simple(x, y, context: 'CompareContext'):
         return context.label('x', repr_x) + ' != ' + context.label('y', repr_y)
 
 
-def _extract_attrs(obj, ignore: Iterable[str] = None) -> Optional[Dict[str, Any]]:
+def _extract_attrs(obj, ignore: Iterable[str] | None = None) -> Optional[Dict[str, Any]]:
     try:
         attrs = vars(obj).copy()
     except TypeError:
@@ -558,8 +558,8 @@ class CompareContext:
             recursive: bool = True,
             strict: bool = False,
             ignore_eq: bool = False,
-            comparers: Registry = None,
-            options: Dict[str, Any] = None,
+            comparers: Registry | None = None,
+            options: Dict[str, Any] | None = None,
     ):
         self.registries = []
         if comparers:
@@ -706,15 +706,15 @@ def compare(
         y: Any = unspecified,
         expected: Any = unspecified,
         actual: Any = unspecified,
-        prefix: str = None,
-        suffix: str = None,
-        x_label: str = None,
-        y_label: str = None,
+        prefix: str | None = None,
+        suffix: str | None = None,
+        x_label: str | None = None,
+        y_label: str | None = None,
         raises: bool = True,
         recursive: bool = True,
         strict: bool = False,
         ignore_eq: bool = False,
-        comparers: Registry = None,
+        comparers: Registry | None = None,
         **options: Any
 ) -> Optional[str]:
     """
@@ -852,7 +852,7 @@ class Comparison(StatefulComparison):
 
     def __init__(self,
                  object_or_type,
-                 attribute_dict: Dict[str, Any] = None,
+                 attribute_dict: Dict[str, Any] | None = None,
                  partial: bool = False,
                  **attributes: Any):
         self.partial = partial
@@ -1183,7 +1183,7 @@ class StringComparison:
 
     :param flag_names: See the :ref:`examples <stringcomparison>`.
     """
-    def __init__(self, regex_source: str, flags: int = None, **flag_names: str):
+    def __init__(self, regex_source: str, flags: int | None = None, **flag_names: str):
         args = [regex_source]
 
         flags_ = []

--- a/testfixtures/datetime.py
+++ b/testfixtures/datetime.py
@@ -1,6 +1,6 @@
 from calendar import timegm
 from datetime import datetime, timedelta, date, tzinfo as TZInfo
-from typing import Optional, Callable, Type, Tuple, Dict, Any, cast, overload
+from typing import Callable, Type, Tuple, Dict, Any, cast, overload
 
 
 class Queue(list):
@@ -9,7 +9,7 @@ class Queue(list):
     delta_delta: float
     delta_type: str
 
-    def __init__(self, delta: Optional[float], delta_delta: float, delta_type: str):
+    def __init__(self, delta: float | None, delta_delta: float, delta_type: str):
         super().__init__()
         if delta is None:
             self.delta = 0
@@ -36,7 +36,7 @@ class MockedCurrent:
     _mock_queue: Queue
     _mock_base_class: Type
     _mock_class: Type
-    _mock_tzinfo: Optional[TZInfo]
+    _mock_tzinfo: TZInfo | None
     _mock_date_type: Type[date]
     _correct_mock_type: Callable = None
 
@@ -107,7 +107,7 @@ def mock_factory(
         default: Tuple[int, ...],
         args: tuple,
         kw: Dict[str, Any],
-        delta: Optional[float],
+        delta: float | None,
         delta_type: str,
         delta_delta: float = 1,
         date_type: Type[date] | None = None,

--- a/testfixtures/datetime.py
+++ b/testfixtures/datetime.py
@@ -43,10 +43,10 @@ class MockedCurrent:
     def __init_subclass__(
             cls,
             concrete: bool = False,
-            queue: Queue = None,
-            strict: bool = None,
-            tzinfo: TZInfo = None,
-            date_type: Type[date] = None
+            queue: Queue | None = None,
+            strict: bool | None = None,
+            tzinfo: TZInfo | None = None,
+            date_type: Type[date] | None = None
     ):
         if concrete:
             cls._mock_queue = queue
@@ -110,8 +110,8 @@ def mock_factory(
         delta: Optional[float],
         delta_type: str,
         delta_delta: float = 1,
-        date_type: Type[date] = None,
-        tzinfo: TZInfo = None,
+        date_type: Type[date] | None = None,
+        tzinfo: TZInfo | None = None,
         strict: bool = False
 ):
     cls = cast(Type[MockedCurrent], type(
@@ -252,7 +252,7 @@ class MockDateTime(MockedCurrent, datetime):
         )
 
     @classmethod
-    def now(cls, tz: TZInfo = None) -> datetime:
+    def now(cls, tz: TZInfo | None = None) -> datetime:
         """
         :param tz: An optional timezone to apply to the returned time.
                 If supplied, it must be an instance of a
@@ -297,8 +297,8 @@ class MockDateTime(MockedCurrent, datetime):
 
 @overload
 def mock_datetime(
-        tzinfo: TZInfo = None,
-        delta: float = None,
+        tzinfo: TZInfo | None = None,
+        delta: float | None = None,
         delta_type: str = 'seconds',
         date_type: Type[date] = date,
         strict: bool = False
@@ -315,8 +315,8 @@ def mock_datetime(
         minute: int = ...,
         second: int = ...,
         microsecond: int = ...,
-        tzinfo: TZInfo = None,
-        delta: float = None,
+        tzinfo: TZInfo | None = None,
+        delta: float | None = None,
         delta_type: str = 'seconds',
         date_type: Type[date] = date,
         strict: bool = False
@@ -327,8 +327,8 @@ def mock_datetime(
 @overload
 def mock_datetime(
         default: datetime,
-        tzinfo: TZInfo = None,
-        delta: float = None,
+        tzinfo: TZInfo | None = None,
+        delta: float | None = None,
         delta_type: str = 'seconds',
         date_type: Type[date] = date,
         strict: bool = False
@@ -339,8 +339,8 @@ def mock_datetime(
 @overload
 def mock_datetime(
         default: None,  # explicit None positional
-        tzinfo: TZInfo = None,
-        delta: float = None,
+        tzinfo: TZInfo | None = None,
+        delta: float | None = None,
         delta_type: str = 'seconds',
         date_type: Type[date] = date,
         strict: bool = False
@@ -350,8 +350,8 @@ def mock_datetime(
 
 def mock_datetime(
         *args,
-        tzinfo: TZInfo = None,
-        delta: float = None,
+        tzinfo: TZInfo | None = None,
+        delta: float | None = None,
         delta_type: str = 'seconds',
         date_type: Type[date] = date,
         strict: bool = False,
@@ -549,8 +549,8 @@ class MockDate(MockedCurrent, date):
 
 @overload
 def mock_date(
-        delta: float = None,
-        delta_type: str = None,
+        delta: float | None = None,
+        delta_type: str | None = None,
         date_type: Type[date] = date,
         strict: bool = False
 ) -> Type[MockDate]:
@@ -562,7 +562,7 @@ def mock_date(
         year: int,
         month: int,
         day: int,
-        delta: float = None,
+        delta: float | None = None,
         delta_type: str = 'days',
         strict: bool = False,
 ) -> Type[MockDate]:
@@ -572,7 +572,7 @@ def mock_date(
 @overload
 def mock_date(
         default: date,
-        delta: float = None,
+        delta: float | None = None,
         delta_type: str = 'days',
         strict: bool = False,
 ) -> Type[MockDate]:
@@ -582,7 +582,7 @@ def mock_date(
 @overload
 def mock_date(
         default: None,  # explicit None positional
-        delta: float = None,
+        delta: float | None = None,
         delta_type: str = 'days',
         strict: bool = False,
 ) -> Type[MockDate]:
@@ -591,7 +591,7 @@ def mock_date(
 
 def mock_date(
         *args,
-        delta: float = None,
+        delta: float | None = None,
         delta_type: str = 'days',
         strict: bool = False,
         **kw
@@ -768,7 +768,7 @@ class MockTime(MockedCurrent, datetime):
 
 @overload
 def mock_time(
-        delta: float = None,
+        delta: float | None = None,
         delta_type: str = 'seconds',
 ) -> Type[MockTime]:
     ...
@@ -783,7 +783,7 @@ def mock_time(
         minute: int = ...,
         second: int = ...,
         microsecond: int = ...,
-        delta: float = None,
+        delta: float | None = None,
         delta_type: str = 'seconds',
 ) -> Type[MockTime]:
     ...
@@ -792,7 +792,7 @@ def mock_time(
 @overload
 def mock_time(
         default: datetime,
-        delta: float = None,
+        delta: float | None = None,
         delta_type: str = 'seconds',
 ) -> Type[MockTime]:
     ...
@@ -801,13 +801,13 @@ def mock_time(
 @overload
 def mock_time(
         default: None,  # explicit None positional
-        delta: float = None,
+        delta: float | None = None,
         delta_type: str = 'seconds',
 ) -> Type[MockTime]:
     ...
 
 
-def mock_time(*args, delta: float = None, delta_type: str = 'seconds', **kw) -> Type[MockTime]:
+def mock_time(*args, delta: float | None = None, delta_type: str = 'seconds', **kw) -> Type[MockTime]:
     """
     .. currentmodule:: testfixtures.datetime
 

--- a/testfixtures/django.py
+++ b/testfixtures/django.py
@@ -50,7 +50,7 @@ def compare_model(x, y, context: CompareContext):
     """
     ignore_fields = context.get_option('ignore_fields', set())
     non_editable_fields= context.get_option('non_editable_fields', False)
-    args = []
+    args: Any = []
     for obj in x, y:
         args.append(model_to_dict(obj, ignore_fields, non_editable_fields))
     args.append(context)

--- a/testfixtures/django.py
+++ b/testfixtures/django.py
@@ -67,15 +67,15 @@ def compare(
         y: Any = unspecified,
         expected: Any = unspecified,
         actual: Any = unspecified,
-        prefix: str = None,
-        suffix: str = None,
-        x_label: str = None,
-        y_label: str = None,
+        prefix: str | None = None,
+        suffix: str | None = None,
+        x_label: str | None = None,
+        y_label: str | None = None,
         raises: bool = True,
         recursive: bool = True,
         strict: bool = False,
         ignore_eq: bool = True,
-        comparers: Registry = None,
+        comparers: Registry | None = None,
         **options: Any
 ) -> Optional[str]:
     """

--- a/testfixtures/django.py
+++ b/testfixtures/django.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Sequence, Optional
+from typing import Dict, Any, Sequence
 
 from django.db.models import Model
 
@@ -77,7 +77,7 @@ def compare(
         ignore_eq: bool = True,
         comparers: Registry | None = None,
         **options: Any
-) -> Optional[str]:
+) -> str | None:
     """
     This is identical to :func:`~testfixtures.compare`, but with ``ignore=True``
     automatically set to make comparing django :class:`~django.db.models.Model`

--- a/testfixtures/logcapture.py
+++ b/testfixtures/logcapture.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from logging import LogRecord
-from typing import List, Union, Tuple, Sequence, Callable, Any
+from typing import List, Tuple, Sequence, Callable, Any
 import atexit
 import logging
 import warnings
@@ -64,11 +64,11 @@ class LogCapture(logging.Handler):
 
     def __init__(
             self,
-            names: Union[str, Tuple[str, ...]] | None = None,
+            names: str | Tuple[str, ...] | None = None,
             install: bool = True,
             level: int = 1,
             propagate: bool | None = None,
-            attributes: Union[Sequence[str], Callable[[LogRecord], Any]] = (
+            attributes: Sequence[str] | Callable[[LogRecord], Any] = (
                     'name', 'levelname', 'getMessage'
             ),
             recursive_check: bool = False,

--- a/testfixtures/logcapture.py
+++ b/testfixtures/logcapture.py
@@ -64,15 +64,15 @@ class LogCapture(logging.Handler):
 
     def __init__(
             self,
-            names: Union[str, Tuple[str, ...]] = None,
+            names: Union[str, Tuple[str, ...]] | None = None,
             install: bool = True,
             level: int = 1,
-            propagate: bool = None,
+            propagate: bool | None = None,
             attributes: Union[Sequence[str], Callable[[LogRecord], Any]] = (
                     'name', 'levelname', 'getMessage'
             ),
             recursive_check: bool = False,
-            ensure_checks_above: int = None
+            ensure_checks_above: int | None = None
     ):
         logging.Handler.__init__(self)
         if not isinstance(names, tuple):
@@ -129,7 +129,7 @@ class LogCapture(logging.Handler):
         for record in self.records:
             record.checked = True
 
-    def ensure_checked(self, level: int = None):
+    def ensure_checked(self, level: int | None = None):
         """
         Ensure every entry logged above the specified `level` has been checked.
         Raises an :class:`AssertionError` if this is not the case.

--- a/testfixtures/logcapture.py
+++ b/testfixtures/logcapture.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from logging import LogRecord
-from typing import List, Union, Tuple, Sequence, Callable, Any, Optional
+from typing import List, Union, Tuple, Sequence, Callable, Any
 import atexit
 import logging
 import warnings
@@ -55,7 +55,7 @@ class LogCapture(logging.Handler):
     #: The records captured by this :class:`LogCapture`.
     records: List[LogRecord]
     #: The log level above which checks must be made for logged events.
-    ensure_checks_above: Optional[int]
+    ensure_checks_above: int | None
 
     instances = set()
     atexit_setup = False

--- a/testfixtures/mock.py
+++ b/testfixtures/mock.py
@@ -10,27 +10,26 @@ __ https://mock.readthedocs.io
 """
 import sys
 
+backport_version: tuple[int, int, int] | None
+
 try:
     from mock import *
-    from mock.mock import _Call
+    from mock.mock import _Call, _Sentinel
     from mock.mock import call as mock_call
     from mock import version_info as backport_version
 except ImportError:
     backport_version = None
     class MockCall:
         pass
-    mock_call = MockCall()
-    try:
-        from unittest.mock import *
-        from unittest.mock import _Call
-    except ImportError:  # pragma: no cover
-        pass
+    mock_call = MockCall()  # type: ignore[assignment]
+    from unittest.mock import *  # type: ignore[assignment]
+    from unittest.mock import _Call, _Sentinel  # type: ignore[assignment]
 
 
 has_backport = backport_version is not None
 
 if not (
-        (has_backport and backport_version[:3] > (2, 0, 0)) or
+        (has_backport and backport_version[:3] > (2, 0, 0)) or  # type: ignore[index]
         (sys.version_info < (3, 0, 0) and not has_backport) or
         (3, 6, 7) < sys.version_info[:3] < (3, 7, 0) or
         sys.version_info[:3] > (3, 7, 1)

--- a/testfixtures/popen.py
+++ b/testfixtures/popen.py
@@ -5,13 +5,13 @@ from itertools import chain, zip_longest
 from os import PathLike
 from subprocess import STDOUT, PIPE
 from tempfile import TemporaryFile
-from typing import Union, Callable, List, Sequence, Tuple, Dict, Iterable
+from typing import Callable, List, Sequence, Tuple, Dict, Iterable, TypeAlias
 
 from testfixtures.utils import extend_docstring
 from .mock import Mock, call, _Call as Call
 
-AnyStr = Union[str, bytes]
-Command = Union[str, bytes, PathLike, Sequence[str], Sequence[bytes]]
+AnyStr: TypeAlias = str | bytes
+Command: TypeAlias = str | bytes | PathLike | Sequence[str] | Sequence[bytes]
 
 
 def shell_join(command: Command) -> str:
@@ -244,7 +244,7 @@ class MockPopen:
             returncode: int = 0,
             pid: int = 1234,
             poll_count: int = 3,
-            behaviour: Union[PopenBehaviour, Callable] | None = None
+            behaviour: PopenBehaviour | Callable | None = None
     ):
         """
         Set the behaviour of this mock when it is used to simulate the

--- a/testfixtures/popen.py
+++ b/testfixtures/popen.py
@@ -75,7 +75,7 @@ class MockPopenInstance:
     #: A :class:`~unittest.mock.Mock` representing the pipe into this process.
     #: This is only set if ``stdin=PIPE`` is passed the constructor.
     #: The mock records writes and closes in :attr:`MockPopen.all_calls`.
-    stdin: Mock = None
+    stdin: Mock | None = None
 
     #: A file representing standard output from this process.
     stdout: TemporaryFile = None
@@ -169,13 +169,13 @@ class MockPopenInstance:
                 stream.close()
 
     @record
-    def wait(self, timeout: float = None) -> int:
+    def wait(self, timeout: float | None = None) -> int:
         "Simulate calls to :meth:`subprocess.Popen.wait`"
         self.returncode = self.behaviour.returncode
         return self.returncode
 
     @record
-    def communicate(self, input: AnyStr = None, timeout: float = None) -> Tuple[AnyStr, AnyStr]:
+    def communicate(self, input: AnyStr | None = None, timeout: float | None = None) -> Tuple[AnyStr, AnyStr]:
         "Simulate calls to :meth:`subprocess.Popen.communicate`"
         self.returncode = self.behaviour.returncode
         return (self.stdout and self.stdout.read(),
@@ -218,7 +218,7 @@ class MockPopen:
     :func:`unittest.mock.patch` or a :class:`~testfixtures.Replacer`.
     """
 
-    default_behaviour: PopenBehaviour = None
+    default_behaviour: PopenBehaviour | None = None
 
     def __init__(self):
         self.commands: Dict[str, PopenBehaviour] = {}
@@ -244,7 +244,7 @@ class MockPopen:
             returncode: int = 0,
             pid: int = 1234,
             poll_count: int = 3,
-            behaviour: Union[PopenBehaviour, Callable] = None
+            behaviour: Union[PopenBehaviour, Callable] | None = None
     ):
         """
         Set the behaviour of this mock when it is used to simulate the

--- a/testfixtures/popen.py
+++ b/testfixtures/popen.py
@@ -5,10 +5,10 @@ from itertools import chain, zip_longest
 from os import PathLike
 from subprocess import STDOUT, PIPE
 from tempfile import TemporaryFile
-from testfixtures.utils import extend_docstring
-from typing import Union, Callable, List, Optional, Sequence, Tuple, Dict, Iterable
-from .mock import Mock, call, _Call as Call
+from typing import Union, Callable, List, Sequence, Tuple, Dict, Iterable
 
+from testfixtures.utils import extend_docstring
+from .mock import Mock, call, _Call as Call
 
 AnyStr = Union[str, bytes]
 Command = Union[str, bytes, PathLike, Sequence[str], Sequence[bytes]]
@@ -147,7 +147,7 @@ class MockPopenInstance:
 
         self.pid: int = behaviour.pid
         #: The return code of this mock process.
-        self.returncode: Optional[int] = None
+        self.returncode: int | None = None
         self.args: Command = args
 
     def _record(self, names, *args, **kw):
@@ -182,7 +182,7 @@ class MockPopenInstance:
                 self.stderr and self.stderr.read())
 
     @record
-    def poll(self) -> Optional[int]:
+    def poll(self) -> int | None:
         "Simulate calls to :meth:`subprocess.Popen.poll`"
         while self.poll_count and self.returncode is None:
             self.poll_count -= 1

--- a/testfixtures/replace.py
+++ b/testfixtures/replace.py
@@ -52,9 +52,9 @@ class Replacer:
             target: Any,
             replacement: R,
             strict: bool = True,
-            container: Any = None,
-            accessor: Accessor = None,
-            name: str = None,
+            container: Any | None = None,
+            accessor: Accessor | None = None,
+            name: str | None = None,
             sep: str = '.',
     ) -> R:
         """
@@ -147,7 +147,7 @@ class Replacer:
         return replacement
 
     def replace(self, target: Any, replacement: Any, strict: bool = True,
-                container: Any = None, accessor: Accessor = None, name: str = None) -> None:
+                container: Any | None = None, accessor: Accessor | None = None, name: str | None = None) -> None:
         """
         Replace the specified target with the supplied replacement.
         """
@@ -175,7 +175,7 @@ class Replacer:
                             return container, None
         return None, None
 
-    def on_class(self, attribute: Callable, replacement: Any, name: str = None) -> None:
+    def on_class(self, attribute: Callable, replacement: Any, name: str | None = None) -> None:
         """
         This method provides a convenient way to replace methods, static methods and class
         methods on their classes.
@@ -203,7 +203,7 @@ class Replacer:
 
         self(container, name=name, accessor=getattr, replacement=replacement)
 
-    def in_module(self, target: Any, replacement: Any, module: ModuleType = None) -> None:
+    def in_module(self, target: Any, replacement: Any, module: ModuleType | None = None) -> None:
         """
         This method provides a convenient way to replace targets that are module globals,
         particularly functions or other objects with a ``__name__`` attribute.
@@ -243,7 +243,7 @@ class Replacer:
 
 def replace(
         target: Any, replacement: Any, strict: bool = True,
-        container: Any = None, accessor: Accessor = None, name: str = None, sep: str ='.'
+        container: Any | None = None, accessor: Accessor | None = None, name: str | None = None, sep: str ='.'
 ) -> Callable[[Callable], Callable]:
     """
     A decorator to replace a target object for the duration of a test
@@ -267,7 +267,7 @@ def replace_in_environ(name: str, replacement: Any):
 
 
 @contextmanager
-def replace_on_class(attribute: Callable, replacement: Any, name: str = None):
+def replace_on_class(attribute: Callable, replacement: Any, name: str | None = None):
     """
     This context manager provides a quick way to use :meth:`Replacer.on_class`.
     """
@@ -277,7 +277,7 @@ def replace_on_class(attribute: Callable, replacement: Any, name: str = None):
 
 
 @contextmanager
-def replace_in_module(target: Any, replacement: Any, module: ModuleType = None):
+def replace_in_module(target: Any, replacement: Any, module: ModuleType | None = None):
     """
     This context manager provides a quick way to use :meth:`Replacer.in_module`.
     """
@@ -293,7 +293,7 @@ class Replace:
 
     def __init__(
             self, target: Any, replacement: R, strict: bool = True,
-            container: Any = None, accessor: Accessor = None, name: str = None, sep: str ='.'
+            container: Any | None = None, accessor: Accessor | None = None, name: str | None = None, sep: str ='.'
     ):
         self.target = target
         self.replacement = replacement

--- a/testfixtures/resolve.py
+++ b/testfixtures/resolve.py
@@ -1,5 +1,5 @@
 from operator import setitem
-from typing import Any, Callable, Optional, Tuple
+from typing import Any, Callable, Tuple
 
 from testfixtures import not_there
 
@@ -23,7 +23,7 @@ class Resolved:
         return f'<Resolved: {self.found}>'
 
 
-def resolve(dotted_name: str, container: Optional[Any] = None, sep: str = '.') -> Resolved:
+def resolve(dotted_name: str, container: Any | None = None, sep: str = '.') -> Resolved:
     names = dotted_name.split(sep)
     used = names.pop(0)
     if container is None:

--- a/testfixtures/shouldraise.py
+++ b/testfixtures/shouldraise.py
@@ -1,10 +1,10 @@
 from contextlib import contextmanager
 from functools import wraps
-from typing import Union, Type, Callable
+from typing import Type, Callable, TypeAlias
 
 from testfixtures import diff, compare
 
-ExceptionOrType = Union[BaseException, Type[BaseException]]
+ExceptionOrType: TypeAlias = BaseException | Type[BaseException]
 
 
 param_docs = """

--- a/testfixtures/shouldraise.py
+++ b/testfixtures/shouldraise.py
@@ -39,7 +39,7 @@ class ShouldRaise:
     #: Can be used to inspect specific attributes of the exception.
     raised = None
 
-    def __init__(self, exception: ExceptionOrType = None, unless: bool = False):
+    def __init__(self, exception: ExceptionOrType | None = None, unless: bool = False):
         self.exception = exception
         self.expected = not unless
 
@@ -78,7 +78,7 @@ class should_raise:
     raised.
     """ + param_docs
 
-    def __init__(self, exception: ExceptionOrType = None, unless: bool = None):
+    def __init__(self, exception: ExceptionOrType | None = None, unless: bool | None = None):
         self.exception = exception
         self.unless = unless
 

--- a/testfixtures/shouldwarn.py
+++ b/testfixtures/shouldwarn.py
@@ -1,10 +1,10 @@
 import warnings
-from typing import Union, Type
+from typing import Type, TypeAlias
 
 from testfixtures import Comparison, SequenceComparison, compare
 
 
-WarningOrType = Union[Warning, Type[Warning]]
+WarningOrType: TypeAlias = Warning | Type[Warning]
 
 
 class ShouldWarn(warnings.catch_warnings):

--- a/testfixtures/tempdirectory.py
+++ b/testfixtures/tempdirectory.py
@@ -49,11 +49,11 @@ class TempDirectory:
 
     def __init__(
             self,
-            path: Union[str, Path] = None,
+            path: Union[str, Path] | None = None,
             *,
             ignore: Sequence[str] = (),
-            create: bool = None,
-            encoding: str = None,
+            create: bool | None = None,
+            encoding: str | None = None,
             cwd: bool = False,
     ):
         self.ignore = []
@@ -118,7 +118,7 @@ class TempDirectory:
 
     def actual(
             self,
-            path: PathStrings = None,
+            path: PathStrings | None = None,
             recursive: bool = False,
             files_only: bool = False,
             followlinks: bool = False,
@@ -156,7 +156,7 @@ class TempDirectory:
             filtered.append(path)
         return filtered
 
-    def listdir(self, path: PathStrings = None, recursive: bool = False):
+    def listdir(self, path: PathStrings | None = None, recursive: bool = False):
         """
         Print the contents of the specified directory.
 
@@ -188,7 +188,7 @@ class TempDirectory:
     def compare(
             self,
             expected: Sequence[str],
-            path: PathStrings = None,
+            path: PathStrings | None = None,
             files_only: bool = False,
             recursive: bool = True,
             followlinks: bool = False,
@@ -265,7 +265,7 @@ class TempDirectory:
         os.makedirs(thepath)
         return thepath
 
-    def write(self, filepath: PathStrings, data: Union[bytes, str], encoding: str = None):
+    def write(self, filepath: PathStrings, data: Union[bytes, str], encoding: str | None = None):
         """
         Write the supplied data to a file at the specified path within
         the temporary directory. Any subdirectories specified that do
@@ -307,7 +307,7 @@ class TempDirectory:
             f.write(data)
         return thepath
 
-    def as_string(self, path: Union[str, Sequence[str]] = None) -> str:
+    def as_string(self, path: Union[str, Sequence[str]] | None = None) -> str:
         """
         Return the full path on disk that corresponds to the path
         relative to the temporary directory that is passed in.
@@ -328,7 +328,7 @@ class TempDirectory:
     #:   Use :meth:`as_string` instead.
     getpath = as_string
 
-    def as_path(self, path: PathStrings = None) -> Path:
+    def as_path(self, path: PathStrings | None = None) -> Path:
         """
         Return the :class:`~pathlib.Path` that corresponds to the path
         relative to the temporary directory that is passed in.
@@ -344,7 +344,7 @@ class TempDirectory:
     def __truediv__(self, other: str) -> Path:
         return self.as_path() / other
 
-    def read(self, filepath: PathStrings, encoding: str = None) -> Union[bytes, str]:
+    def read(self, filepath: PathStrings, encoding: str | None = None) -> Union[bytes, str]:
         """
         Reads the file at the specified path within the temporary
         directory.

--- a/testfixtures/tempdirectory.py
+++ b/testfixtures/tempdirectory.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from re import compile
 from tempfile import mkdtemp
-from typing import Union, Sequence, TYPE_CHECKING, Tuple, Callable
+from typing import Sequence, Tuple, Callable, TypeAlias
 
 from testfixtures.comparison import compare
 from testfixtures.utils import wrap
@@ -13,7 +13,7 @@ from testfixtures.utils import wrap
 from .rmtree import rmtree
 
 
-PathStrings = Union[str, Tuple[str, ...]]
+PathStrings: TypeAlias = str | Tuple[str, ...]
 
 
 class TempDirectory:
@@ -49,7 +49,7 @@ class TempDirectory:
 
     def __init__(
             self,
-            path: Union[str, Path] | None = None,
+            path: str | Path | None = None,
             *,
             ignore: Sequence[str] = (),
             create: bool | None = None,
@@ -265,7 +265,7 @@ class TempDirectory:
         os.makedirs(thepath)
         return thepath
 
-    def write(self, filepath: PathStrings, data: Union[bytes, str], encoding: str | None = None):
+    def write(self, filepath: PathStrings, data: str | bytes, encoding: str | None = None):
         """
         Write the supplied data to a file at the specified path within
         the temporary directory. Any subdirectories specified that do
@@ -307,7 +307,7 @@ class TempDirectory:
             f.write(data)
         return thepath
 
-    def as_string(self, path: Union[str, Sequence[str]] | None = None) -> str:
+    def as_string(self, path: str | Sequence[str] | None = None) -> str:
         """
         Return the full path on disk that corresponds to the path
         relative to the temporary directory that is passed in.
@@ -344,7 +344,7 @@ class TempDirectory:
     def __truediv__(self, other: str) -> Path:
         return self.as_path() / other
 
-    def read(self, filepath: PathStrings, encoding: str | None = None) -> Union[bytes, str]:
+    def read(self, filepath: PathStrings, encoding: str | None = None) -> str | bytes:
         """
         Reads the file at the specified path within the temporary
         directory.

--- a/testfixtures/tests/test_replace.py
+++ b/testfixtures/tests/test_replace.py
@@ -411,7 +411,7 @@ class TestReplace(TestCase):
 
                 r.replace('module.submodule.foo', bar)
 
-                from module.submodule import foo
+                from module.submodule import foo  # type: ignore[import-not-found]
                 compare(foo(), "bar")
 
     def test_staticmethod(self):

--- a/testfixtures/tests/test_should_raise.py
+++ b/testfixtures/tests/test_should_raise.py
@@ -206,7 +206,7 @@ class TestShouldRaise(TestCase):
 
     def test_import_errors_1(self):
         with ShouldRaise(ModuleNotFoundError("No module named 'textfixtures'")):
-            import textfixtures.foo.bar
+            import textfixtures.foo.bar  # type: ignore[import-not-found]
 
     def test_import_errors_2(self):
         with ShouldRaise(ImportError('X')):

--- a/testfixtures/tests/test_tempdirectory.py
+++ b/testfixtures/tests/test_tempdirectory.py
@@ -125,6 +125,16 @@ class TempDirectoryTests(TestCase):
         self.assertEqual(d, td.path)
         self.assertFalse(os.path.exists(d))
 
+    def test_delay_create(self):
+        td = TempDirectory(create=False)
+        assert td.path is None
+        with ShouldRaise(RuntimeError('Instantiated with create=False and .create() not called')):
+            td.as_path()
+        td.create()
+        assert td.path is not None
+        td.cleanup()
+        assert td.path is None
+
     def test_compare_sort_actual(self):
         with TempDirectory() as d:
             d.write('ga', b'')
@@ -297,6 +307,11 @@ class TempDirectoryTests(TestCase):
         with TempDirectory(encoding='ascii') as d:
             d.write('test.txt', decoded, encoding='utf-8')
             compare(d.read('test.txt', encoding='utf-8'), expected=decoded)
+
+    def test_attempt_to_encode_bytes(self):
+        with TempDirectory() as d:
+            with ShouldRaise(TypeError("Cannot specify encoding when data is bytes")):
+                d.write('test.txt', b'\xc2\xa3', encoding='utf-8')
 
     def test_as_path_minimal(self):
         with TempDirectory(encoding='ascii') as d:

--- a/testfixtures/twisted.py
+++ b/testfixtures/twisted.py
@@ -2,13 +2,13 @@
 Tools for helping to test Twisted applications.
 """
 from pprint import pformat
-from typing import Union, Sequence, Callable
+from typing import Sequence, Callable
 from unittest import TestCase
 
 from constantly import NamedConstant
+from twisted.logger import globalLogPublisher, formatEvent, LogLevel
 
 from . import compare
-from twisted.logger import globalLogPublisher, formatEvent, LogLevel
 
 
 class LogCapture:
@@ -24,7 +24,7 @@ class LogCapture:
       otherwise they will be a tuple of the specified fields.
     """
 
-    def __init__(self, fields: Sequence[Union[str, Callable]] = ('log_level', formatEvent,)):
+    def __init__(self, fields: Sequence[str | Callable] = ('log_level', formatEvent,)):
         #: The list of events captured.
         self.events = []
         self.fields = fields

--- a/testfixtures/utils.py
+++ b/testfixtures/utils.py
@@ -5,18 +5,7 @@ from textwrap import dedent
 from inspect import getfullargspec
 from typing import Callable, Sequence, Any
 
-from . import singleton
-
-DEFAULT = singleton('DEFAULT')
-defaults = [DEFAULT]
-
-
-try:
-    from .mock import DEFAULT
-except ImportError:  # pragma: no cover
-    pass
-else:
-    defaults.append(DEFAULT)
+from .mock import DEFAULT, _Sentinel
 
 
 def generator(*args):
@@ -33,7 +22,7 @@ class Wrapping:
     attribute_name = None
     new = DEFAULT
 
-    def __init__(self, before: Callable[[], None], after: Callable[[], None]):
+    def __init__(self, before: Callable[[], None], after: Callable[[], None] | None):
         self.before, self.after = before, after
 
     def __enter__(self):
@@ -72,7 +61,7 @@ def wrap(before: Callable[[], Any], after: Callable[[], Any] | None = None):
                     entered_patchers.append(patching)
                     if patching.attribute_name is not None:
                         keywargs.update(arg)
-                    elif patching.new in defaults and added < to_add:
+                    elif patching.new is DEFAULT and added < to_add:
                         extra_args.append(arg)
                         added += 1
 

--- a/testfixtures/utils.py
+++ b/testfixtures/utils.py
@@ -44,7 +44,7 @@ class Wrapping:
             self.after()
 
 
-def wrap(before: Callable[[], Any], after: Callable[[], Any] = None):
+def wrap(before: Callable[[], Any], after: Callable[[], Any] | None = None):
     """
     A decorator that causes the supplied callables to be called before
     or after the wrapped callable, as appropriate.


### PR DESCRIPTION
The aim of this change is to check mypy running against pull requests and passing, even if it's in a super permissive way.
It should also enforce strict typing where possible, with the intention that newly added modules will be fully types and existing modules should eventually get there.