### PR TITLE
More typing work

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,12 +43,15 @@ exclude_patterns = ['**/furo.js.LICENSE.txt']
 
 nitpicky = True
 nitpick_ignore = [
-    ('py:class', 'testfixtures.replace.R'),  # type var
-    ('py:class', 'module'),  # ModuleType not documented.
-    ('py:class', 'unittest.mock._Call'),  # No docstring.
-    ('py:class', 'tempfile.TemporaryFile'),  # not documented as a class so type annotation broken
+    ('py:class', 'P'),  # param spec
     ('py:class', 'constantly._constants.NamedConstant'),  # twisted logging constants
-    ('py:class', 'py.path.local'),  # deprecated and hard to reference
-    ('py:class', 'unittest.case.TestCase'),  # no docs, apparently
+    ('py:class', 'django.db.models.base.Model'),  # not documented upstream
+    ('py:class', 'module'),  # ModuleType not documented.
+    ('py:class', 'tempfile.TemporaryFile'),  # not documented as a class so type annotation broken
+    ('py:class', 'testfixtures.replace.R'),  # type var
+    ('py:class', 'testfixtures.utils.T'),  # type var
+    ('py:class', 'testfixtures.utils.U'),  # type var
     ('py:class', 'twisted.trial.unittest.TestCase'),  # twisted doesn't use sphinx
+    ('py:class', 'unittest.case.TestCase'),  # no docs, apparently
+    ('py:class', 'unittest.mock._Call'),  # No docstring.
 ]

--- a/mypy.ini
+++ b/mypy.ini
@@ -8,6 +8,10 @@ plugins =
 [mypy.plugins.django-stubs]
 django_settings_module = "testfixtures.tests.test_django.settings"
 
+# Things that need to be resolved before adding a py.typed:
+[mypy-testfixtures.datetime]
+disable_error_code = no-untyped-def
+
 # "nice to have" stuff to fix:
 [mypy-testfixtures.tests.*]
 disable_error_code = no-untyped-call,no-untyped-def

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,6 +6,11 @@ plugins =
 [mypy.plugins.django-stubs]
 django_settings_module = "testfixtures.tests.test_django.settings"
 
+# "nice to have" stuff to fix:
+[mypy-testfixtures.tests.*]
+disable_error_code = no-untyped-call,no-untyped-def
+
+# permanent exclusions and workaround:
 [mypy-constantly.*]
 ignore_missing_imports = True
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,8 @@
 [mypy]
 disable_error_code = annotation-unchecked
 plugins =
-    mypy_django_plugin.main
+    mypy_django_plugin.main,
+    mypy_zope:plugin,
 
 [mypy.plugins.django-stubs]
 django_settings_module = "testfixtures.tests.test_django.settings"

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,6 @@
 [mypy]
 disallow_untyped_defs = True
+disallow_incomplete_defs = True
 plugins =
     mypy_django_plugin.main,
     mypy_zope:plugin,

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-disable_error_code = annotation-unchecked
+disallow_untyped_defs = True
 plugins =
     mypy_django_plugin.main,
     mypy_zope:plugin,

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
     extras_require=dict(
         test=['django-stubs',
               'mypy',
+              'mypy-zope',
               'pytest>=7.1',
               'pytest-cov',
               'pytest-django',

--- a/testfixtures/__init__.py
+++ b/testfixtures/__init__.py
@@ -1,9 +1,9 @@
 class singleton:
 
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         self.name = name
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '<%s>' % self.name
 
     __str__ = __repr__

--- a/testfixtures/datetime.py
+++ b/testfixtures/datetime.py
@@ -1,6 +1,6 @@
 from calendar import timegm
 from datetime import datetime, timedelta, date, tzinfo as TZInfo
-from typing import Callable, Tuple, Dict, Any, cast, overload
+from typing import Callable, Tuple, Any, cast, overload
 
 
 class Queue(list):
@@ -107,7 +107,7 @@ def mock_factory(
         mock_class: type[MockedCurrent],
         default: Tuple[int, ...],
         args: tuple,
-        kw: Dict[str, Any],
+        kw: dict[str, Any],
         delta: float | None,
         delta_type: str,
         delta_delta: float = 1,

--- a/testfixtures/django.py
+++ b/testfixtures/django.py
@@ -1,12 +1,12 @@
-from typing import Dict, Any, Sequence
+from typing import Any, Sequence, Iterable
 
-from django.db.models import Model
+from django.db.models import Model, Field
 
 from . import compare as base_compare
 from .comparison import _compare_mapping, register, CompareContext, unspecified, Registry
 
 
-def instance_fields(instance):
+def instance_fields(instance: Model) -> Iterable[Field]:
     opts = instance._meta
     for name in (
         'concrete_fields',
@@ -20,10 +20,10 @@ def instance_fields(instance):
 
 
 def model_to_dict(
-        instance: Any,
+        instance: Model,
         exclude: Sequence[str],
         include_not_editable: bool,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     data = {}
     for f in instance_fields(instance):
         if f.name in exclude:
@@ -34,7 +34,7 @@ def model_to_dict(
     return data
 
 
-def compare_model(x, y, context: CompareContext):
+def compare_model(x: Model, y: Model, context: CompareContext) -> str | None:
     """
     Returns an informative string describing the differences between the two
     supplied Django model instances. The way in which this comparison is
@@ -62,7 +62,7 @@ register(Model, compare_model)
 
 
 def compare(
-        *args,
+        *args: Any,
         x: Any = unspecified,
         y: Any = unspecified,
         expected: Any = unspecified,

--- a/testfixtures/resolve.py
+++ b/testfixtures/resolve.py
@@ -18,7 +18,7 @@ class Resolved:
     def key(self) -> Key:
         return id(self.container), self.setter, self.name
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f'<Resolved: {self.found}>'
 
 
@@ -71,11 +71,11 @@ def resolve(dotted_name: str, container: Any | None = None, sep: str = '.') -> R
 class _Reference:
 
     @classmethod
-    def classmethod(cls):  # pragma: no cover
+    def classmethod(cls) -> None:  # pragma: no cover
         pass
 
     @staticmethod
-    def staticmethod(cls):  # pragma: no cover
+    def staticmethod() -> None:  # pragma: no cover
         pass
 
 

--- a/testfixtures/rmtree.py
+++ b/testfixtures/rmtree.py
@@ -6,6 +6,7 @@ import shutil
 import sys
 import time
 import warnings
+from pathlib import Path
 
 if sys.platform.startswith("win"): # pragma: no cover
     def _waitfor(func, pathname, waitall=False):
@@ -57,7 +58,7 @@ else:
     _rmtree = shutil.rmtree
 
 
-def rmtree(path):
+def rmtree(path: str | Path) -> None:
     try:
         _rmtree(path)
     except OSError as e:  # pragma: no cover

--- a/testfixtures/shouldwarn.py
+++ b/testfixtures/shouldwarn.py
@@ -1,5 +1,6 @@
 import warnings
-from typing import TypeAlias
+from types import TracebackType
+from typing import TypeAlias, Any
 
 from testfixtures import Comparison, SequenceComparison, compare
 
@@ -43,18 +44,25 @@ class ShouldWarn(warnings.catch_warnings):
 
     _empty_okay = False
 
-    def __init__(self, *expected: WarningOrType, order_matters: bool = True, **filters):
+    def __init__(
+            self, *expected: WarningOrType, order_matters: bool = True, **filters: Any
+    ) -> None:
         super(ShouldWarn, self).__init__(record=True)
         self.order_matters = order_matters
         self.expected = [Comparison(e) for e in expected]
         self.filters = filters
 
-    def __enter__(self):
+    def __enter__(self) -> None:
         self.recorded = super(ShouldWarn, self).__enter__()
         warnings.filterwarnings("always", **self.filters)
         return self.recorded
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc_val: BaseException | None,
+            exc_tb: TracebackType | None,
+    ) -> None:
         super(ShouldWarn, self).__exit__(exc_type, exc_val, exc_tb)
         if not self.recorded and self._empty_okay:
             return
@@ -74,5 +82,5 @@ class ShouldNotWarn(ShouldWarn):
 
     _empty_okay = True
 
-    def __init__(self):
+    def __init__(self) -> None:
         super(ShouldNotWarn, self).__init__()

--- a/testfixtures/sybil.py
+++ b/testfixtures/sybil.py
@@ -51,7 +51,7 @@ class FileParser:
                     region.evaluator = self.evaluate
                     yield region
 
-    def evaluate(self, example: Example):
+    def evaluate(self, example: Example) -> str | None:
         block: FileBlock = example.parsed
         temp_directory = example.namespace[self.name]
         if block.action == 'read':
@@ -65,3 +65,4 @@ class FileParser:
                 )
         if block.action == 'write':
             temp_directory.write(block.path, block.content)
+        return None

--- a/testfixtures/twisted.py
+++ b/testfixtures/twisted.py
@@ -2,7 +2,7 @@
 Tools for helping to test Twisted applications.
 """
 from pprint import pformat
-from typing import Sequence, Callable, Any, TypeAlias
+from typing import Sequence, Callable, Any, TypeAlias, Self
 from unittest import TestCase
 
 from constantly import NamedConstant
@@ -33,12 +33,12 @@ class LogCapture:
     def __call__(self, event: LogEvent) -> None:
         self.events.append(event)
 
-    def install(self):
+    def install(self) -> None:
         "Start capturing."
         self.original_observers = globalLogPublisher._observers
         globalLogPublisher._observers = [self]
 
-    def uninstall(self):
+    def uninstall(self) -> None:
         "Stop capturing."
         globalLogPublisher._observers = self.original_observers
 
@@ -80,7 +80,7 @@ class LogCapture:
                     'other entries:\n%s'
                 ) % (pformat(matched), pformat(expected_), pformat(unmatched)))
 
-    def check_failure_text(self, expected: str, index: int = -1, attribute: str = 'value'):
+    def check_failure_text(self, expected: str, index: int = -1, attribute: str = 'value') -> None:
         """
         Check the string representation of an attribute of a logged ``Failure`` is as expected.
 
@@ -90,7 +90,7 @@ class LogCapture:
         """
         compare(expected, actual=str(getattr(self.events[index]['log_failure'], attribute)))
 
-    def raise_logged_failure(self, start_index: int = 0):
+    def raise_logged_failure(self, start_index: int = 0) -> None:
         """
         A debugging tool that raises the first failure encountered in captured logging.
 
@@ -102,7 +102,7 @@ class LogCapture:
                 raise failure
 
     @classmethod
-    def make(cls, testcase: TestCase, **kw):
+    def make(cls, testcase: TestCase, **kw: Sequence[str | Callable]) -> Self:
         """
         Instantiate, install and add a cleanup for a :class:`LogCapture`.
 

--- a/testfixtures/utils.py
+++ b/testfixtures/utils.py
@@ -3,12 +3,13 @@ from functools import wraps
 from textwrap import dedent
 
 from inspect import getfullargspec
-from typing import Callable, Sequence, Any
+from types import TracebackType
+from typing import Callable, Sequence, Any, Generator, TypeVar, Generic, ParamSpec, TypeAlias
 
 from .mock import DEFAULT, _Sentinel
 
 
-def generator(*args):
+def generator(*args: Any) -> Generator[Any, None, None]:
     """
     A utility function for creating a generator that will yield the
     supplied arguments.
@@ -16,24 +17,37 @@ def generator(*args):
     for i in args:
         yield i
 
+T = TypeVar("T")
 
-class Wrapping:
+
+class Wrapping(Generic[T]):
 
     attribute_name = None
     new = DEFAULT
 
-    def __init__(self, before: Callable[[], None], after: Callable[[], None] | None):
+    def __init__(self, before: Callable[[], T], after: Callable[[], None] | None):
         self.before, self.after = before, after
 
-    def __enter__(self):
+    def __enter__(self) -> T:
         return self.before()
 
-    def __exit__(self, exc_type=None, exc_val=None, exc_tb=None):
+    def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc_val: BaseException | None,
+            exc_tb: TracebackType | None,
+    ) -> None:
         if self.after is not None:
             self.after()
 
+ExcInfo: TypeAlias = tuple[type[BaseException] | None, BaseException | None, TracebackType | None]
+P = ParamSpec("P")
+U = TypeVar("U")
 
-def wrap(before: Callable[[], Any], after: Callable[[], Any] | None = None):
+
+def wrap(
+        before: Callable[[], T], after: Callable[[], None] | None = None
+) -> Callable[[Callable[P, U]], Callable[P, U]]:
     """
     A decorator that causes the supplied callables to be called before
     or after the wrapped callable, as appropriate.
@@ -41,22 +55,22 @@ def wrap(before: Callable[[], Any], after: Callable[[], Any] | None = None):
 
     wrapping = Wrapping(before, after)
 
-    def wrapper(func):
+    def wrapper(func: Callable[P, U]) -> Callable[P, U]:
         if hasattr(func, 'patchings'):
             func.patchings.append(wrapping)
             return func
 
         @wraps(func)
-        def patched(*args, **keywargs):
+        def patched(*args: P.args, **keywargs: P.kwargs) -> U:
             extra_args = []
             entered_patchers = []
 
             to_add = len(getfullargspec(func).args[len(args):])
             added = 0
 
-            exc_info = (None, None, None)
+            exc_info: ExcInfo = (None, None, None)
             try:
-                for patching in patched.patchings:
+                for patching in patched.patchings:  # type: ignore[attr-defined]
                     arg = patching.__enter__()
                     entered_patchers.append(patching)
                     if patching.attribute_name is not None:
@@ -65,7 +79,7 @@ def wrap(before: Callable[[], Any], after: Callable[[], Any] | None = None):
                         extra_args.append(arg)
                         added += 1
 
-                args += tuple(extra_args)
+                args += tuple(extra_args)  # type: ignore[assignment]
                 return func(*args, **keywargs)
             except:
                 # Pass the exception to __exit__
@@ -76,18 +90,18 @@ def wrap(before: Callable[[], Any], after: Callable[[], Any] | None = None):
                 for patching in reversed(entered_patchers):
                     patching.__exit__(*exc_info)
 
-        patched.patchings = [wrapping]
+        patched.patchings = [wrapping]  # type: ignore[attr-defined]
         return patched
 
     return wrapper
 
 
-def extend_docstring(docstring: str, objs: Sequence):
+def extend_docstring(docstring: str, objs: Sequence) -> None:
     for obj in objs:
         obj.__doc__ = dedent(obj.__doc__) + docstring
 
 
-def indent(text: str, indent_size: int = 2):
+def indent(text: str, indent_size: int = 2) -> str:
     indented = []
     for do_indent, line in enumerate(text.splitlines(True)):
         if do_indent:


### PR DESCRIPTION
The aim of this pull request is to get to a point where non-strict mypy passes with `disallow_untyped_defs = True` and `disallow_incomplete_defs = True`, except in tests.

This should allow an experiment to see if it's safe/sane to ship a `testfixtures` release with a `py.typed` marker file.

Things to do:

- [x] get everything passing with `disallow_untyped_defs = True`
- [x] get everything passing with `disallow_incomplete_defs = True`
- [x] remove the need for `annotation-unchecked` for `testfixtures.popen`
- [x] remove the need for `annotation-unchecked` for `testfixtures.replace`
- [X] ~sort out the typing in testfixtures.datetime, which may need a rewrite :-/ ~ Defer to a separate PR