### PR TITLE
Add support for `StringComparison` as parameters to `OutputCapture.compare()`

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -19,6 +19,9 @@ enable_error_code = no-untyped-call,no-untyped-def
 [mypy-testfixtures.tests.test_datetime]
 enable_error_code = no-untyped-call,no-untyped-def
 
+[mypy-testfixtures.tests.test_outputcapture]
+enable_error_code = no-untyped-call,no-untyped-def
+
 [mypy-testfixtures.tests.test_should_raise]
 enable_error_code = no-untyped-call,no-untyped-def
 

--- a/testfixtures/outputcapture.py
+++ b/testfixtures/outputcapture.py
@@ -4,7 +4,7 @@ from io import StringIO
 from tempfile import TemporaryFile
 from typing import Self, Any, IO
 
-from testfixtures.comparison import compare
+from .comparison import StringComparison, compare
 
 
 class OutputCapture:
@@ -106,7 +106,12 @@ class OutputCapture:
         "A property containing any output that has been captured so far."
         return self._read(self.output)
 
-    def compare(self, expected: str = '', stdout: str = '', stderr: str = '') -> None:
+    def compare(
+            self,
+            expected: str | StringComparison = '',
+            stdout: str | StringComparison = '',
+            stderr: str | StringComparison = ''
+    ) -> None:
         """
         Compare the captured output to that expected. If the output is
         not the same, an :class:`AssertionError` will be raised.
@@ -126,7 +131,8 @@ class OutputCapture:
                 ('stderr', stderr, self._read(self.stderr)),
         ):
             if self.strip_whitespace:
-                _expected = _expected.strip()
+                if isinstance(_expected, str):
+                    _expected = _expected.strip()
                 captured = captured.strip()
             if _expected != captured:
                 expected_mapping[prefix] = _expected

--- a/testfixtures/tests/test_outputcapture.py
+++ b/testfixtures/tests/test_outputcapture.py
@@ -2,18 +2,19 @@ import sys
 from subprocess import call
 from unittest import TestCase
 
+from _pytest.capture import CaptureFixture
 from testfixtures import OutputCapture, compare
 from .test_compare import CompareHelper
 
 
 class TestOutputCapture(CompareHelper, TestCase):
 
-    def test_compare_strips(self):
+    def test_compare_strips(self) -> None:
         with OutputCapture() as o:
             print(' Bar! ')
         o.compare('Bar!')
 
-    def test_compare_doesnt_strip(self):
+    def test_compare_doesnt_strip(self) -> None:
         with OutputCapture(strip_whitespace=False) as o:
             print(' Bar! ')
         self.check_raises(
@@ -22,7 +23,7 @@ class TestOutputCapture(CompareHelper, TestCase):
             message="'\\tBar!' (expected) != ' Bar! \\n' (actual)",
         )
 
-    def test_stdout_and_stderr(self):
+    def test_stdout_and_stderr(self) -> None:
         with OutputCapture() as o:
             print('hello', file=sys.stdout)
             print('out', file=sys.stderr)
@@ -30,12 +31,12 @@ class TestOutputCapture(CompareHelper, TestCase):
             print('now', file=sys.stderr)
         o.compare("hello\nout\nthere\nnow\n")
 
-    def test_unicode(self):
+    def test_unicode(self) -> None:
         with OutputCapture() as o:
             print(u'\u65e5', file=sys.stdout)
         o.compare(u'\u65e5\n')
 
-    def test_separate_capture(self):
+    def test_separate_capture(self) -> None:
         with OutputCapture(separate=True) as o:
             print('hello', file=sys.stdout)
             print('out', file=sys.stderr)
@@ -44,7 +45,7 @@ class TestOutputCapture(CompareHelper, TestCase):
         o.compare(stdout="hello\nthere\n",
                   stderr="out\nnow\n")
 
-    def test_compare_both_at_once(self):
+    def test_compare_both_at_once(self) -> None:
         with OutputCapture(separate=True) as o:
             print('hello', file=sys.stdout)
             print('out', file=sys.stderr)
@@ -65,7 +66,7 @@ class TestOutputCapture(CompareHelper, TestCase):
             ),
         )
 
-    def test_original_restore(self):
+    def test_original_restore(self) -> None:
         o_out, o_err = sys.stdout, sys.stderr
         with OutputCapture() as o:
             self.assertFalse(sys.stdout is o_out)
@@ -73,7 +74,7 @@ class TestOutputCapture(CompareHelper, TestCase):
         self.assertTrue(sys.stdout is o_out)
         self.assertTrue(sys.stderr is o_err)
 
-    def test_double_disable(self):
+    def test_double_disable(self) -> None:
         o_out, o_err = sys.stdout, sys.stderr
         with OutputCapture() as o:
             self.assertFalse(sys.stdout is o_out)
@@ -87,7 +88,7 @@ class TestOutputCapture(CompareHelper, TestCase):
         self.assertTrue(sys.stdout is o_out)
         self.assertTrue(sys.stderr is o_err)
 
-    def test_double_enable(self):
+    def test_double_enable(self) -> None:
         o_out, o_err = sys.stdout, sys.stderr
         with OutputCapture() as o:
             o.disable()
@@ -105,14 +106,14 @@ class TestOutputCapture(CompareHelper, TestCase):
 
 class TestOutputCaptureWithDescriptors:
 
-    def test_fd(self, capfd):
+    def test_fd(self, capfd: CaptureFixture) -> None:
         with capfd.disabled(), OutputCapture(fd=True) as o:
             call([sys.executable, '-c', "import sys; sys.stdout.write('out')"])
             call([sys.executable, '-c', "import sys; sys.stderr.write('err')"])
         compare(o.captured, expected='outerr')
         o.compare(expected='outerr')
 
-    def test_fd_separate(self, capfd):
+    def test_fd_separate(self, capfd: CaptureFixture) -> None:
         with capfd.disabled(), OutputCapture(fd=True, separate=True) as o:
             call([sys.executable, '-c', "import sys; sys.stdout.write('out')"])
             call([sys.executable, '-c', "import sys; sys.stderr.write('err')"])

--- a/testfixtures/tests/test_outputcapture.py
+++ b/testfixtures/tests/test_outputcapture.py
@@ -3,7 +3,7 @@ from subprocess import call
 from unittest import TestCase
 
 from _pytest.capture import CaptureFixture
-from testfixtures import OutputCapture, compare
+from testfixtures import OutputCapture, compare, StringComparison
 from .test_compare import CompareHelper
 
 
@@ -102,6 +102,17 @@ class TestOutputCapture(CompareHelper, TestCase):
             self.assertFalse(sys.stderr is o_err)
         self.assertTrue(sys.stdout is o_out)
         self.assertTrue(sys.stderr is o_err)
+
+    def test_compare_expected_is_stringcomparison(self) -> None:
+        with OutputCapture() as output:
+            print('foo')
+        output.compare(StringComparison(r'^foo\Z'))
+
+    def test_compare_stdout_and_stdderr_are_stringcomparisons(self) -> None:
+        with OutputCapture(separate=True) as output:
+            print('hello', file=sys.stdout)
+            print('world', file=sys.stderr)
+        output.compare(stdout=StringComparison(r'^hello\Z'), stderr=StringComparison(r'^world\Z'))
 
 
 class TestOutputCaptureWithDescriptors:

--- a/testfixtures/tests/test_stringcomparison.py
+++ b/testfixtures/tests/test_stringcomparison.py
@@ -19,29 +19,22 @@ class Tests(TestCase):
         self.assertTrue('on xxx' != S(r'on \d+'))
 
     def test_comp_in_sequence(self):
-        self.assertTrue((
-            1, 2, 'on 40220'
-            ) == (
-            1, 2, S(r'on \d+')
-            ))
+        self.assertTrue((1, 2, 'on 40220') == (1, 2, S(r'on \d+')))
 
     def test_not_string(self):
         self.assertFalse(40220 == S(r'on \d+'))
 
     def test_repr(self):
-        compare('<S:on \\d+>',
-                repr(S(r'on \d+')))
+        compare('<S:on \\d+>', repr(S(r'on \d+')))
 
     def test_str(self):
-        compare('<S:on \\d+>',
-                str(S(r'on \d+')))
+        compare('<S:on \\d+>', str(S(r'on \d+')))
 
     def test_sort(self):
         a = S('a')
         b = S('b')
         c = S('c')
-        compare(sorted(('d', c, 'e', a, 'a1', b)),
-                [a, 'a1', b, c, 'd', 'e'])
+        compare(sorted(('d', c, 'e', a, 'a1', b)), expected=[a, 'a1', b, c, 'd', 'e'])
 
     def test_flags_argument(self):
         compare(S(".*bar", re.DOTALL), actual="foo\nbar")


### PR DESCRIPTION
Resolves #212