### PR TITLE
Harden string representation of objects involved in comparison

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -79,6 +79,10 @@ testfixtures.comparers
 
 .. autofunction:: testfixtures.comparers.compare_text
 
+.. autofunction:: testfixtures.comparers.safe_repr
+
+.. autofunction:: testfixtures.comparers.safe_pformat
+
 .. autoclass:: testfixtures.comparers.AlreadySeen
 
 .. currentmodule:: testfixtures

--- a/docs/comparing.rst
+++ b/docs/comparing.rst
@@ -741,6 +741,19 @@ attributes to ignore:
 
   r.restore()
 
+Rendering objects safely in custom comparers
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When a customer comparer builds a message it usually needs to render the objects
+it is comparing. If one of those objects raises an exception as part of that process, the
+caller sees an unrelated traceback instead of any useful comparison message.
+
+:func:`~testfixtures.comparers.safe_repr` and
+:func:`~testfixtures.comparers.safe_pformat` are
+drop-in replacements for :func:`repr` and :func:`pprint.pformat` that catch
+exceptions, but not :class:`BaseException` instances such as :exc:`KeyboardInterrupt`
+or :exc:`SystemExit`, and substitute any failures with a marker.
+
 .. _ignore-eq:
 
 Ignoring ``__eq__``

--- a/src/testfixtures/__init__.py
+++ b/src/testfixtures/__init__.py
@@ -12,7 +12,7 @@ class singleton:
 not_there: singleton = singleton('not_there')
 
 
-from testfixtures.comparers import diff
+from testfixtures.comparers import diff, safe_pformat, safe_repr
 from testfixtures.comparison import (
     Comparison, StringComparison, RoundComparison, compare, RangeComparison,
     SequenceComparison, Subset, Permutation, MappingComparison, like, sequence,
@@ -78,6 +78,8 @@ __all__ = [
     'replace_on_class',
     'replace_in_module',
     'resolve',
+    'safe_pformat',
+    'safe_repr',
     'sequence',
     'should_raise',
     'singleton',

--- a/src/testfixtures/comparers.py
+++ b/src/testfixtures/comparers.py
@@ -23,6 +23,54 @@ if TYPE_CHECKING:
     from .comparison import CompareContext
 
 
+def safe_repr(obj: Any) -> str:
+    """
+    A fault-tolerant version of :func:`repr`.
+
+    :exc:`KeyboardInterrupt` and :exc:`SystemExit` are not caught.
+    """
+    try:
+        return repr(obj)
+    except Exception as e:
+        type_ = type(obj)
+        type_name = type_.__name__
+        match obj:
+            case list():
+                return '[' + ', '.join(safe_repr(e) for e in obj) + ']'
+            case tuple():
+                body = ', '.join(safe_repr(e) for e in obj)
+                suffix = ',)' if len(obj) == 1 else ')'
+                return '(' + body + suffix
+            case dict():
+                body = ', '.join(f'{safe_repr(k)}: {safe_repr(v)}' for k, v in obj.items())
+                return '{' + body + '}'
+            case frozenset():
+                if not obj:
+                    return type_name
+                return type_name + '({' + ', '.join(safe_repr(e) for e in obj) + '})'
+            case set():
+                if not obj:
+                    return type_name + '()'
+                return '{' + ', '.join(safe_repr(e) for e in obj) + '}'
+            case _:
+                try:
+                    detail = f'{type(e).__name__}: {e}'
+                except:
+                    detail = type(e).__name__
+                return f'<unrepresentable {type_.__module__}.{type_.__qualname__}: {detail}>'
+
+
+def safe_pformat(obj: Any) -> str:
+    """
+    A fault-tolerant version of  :func:`pprint.pformat` but tolerant.
+    Falls back to :func:`safe_repr` when :func:`~pprint.pformat` fails.
+    """
+    try:
+        return pformat(obj)
+    except:
+        return safe_repr(obj)
+
+
 class AlreadySeen:
     """
     A marker for an object that has already been seen during a :func:`~testfixtures.compare` call.
@@ -35,7 +83,7 @@ class AlreadySeen:
         self.breadcrumb = breadcrumb
 
     def __repr__(self) -> str:
-        return f'<AlreadySeen for {self.obj!r} at {self.breadcrumb} with id {self.id}>'
+        return f'<AlreadySeen for {safe_repr(self.obj)} at {self.breadcrumb} with id {self.id}>'
 
     def __eq__(self, other: Any)-> bool:
         if isinstance(other, AlreadySeen):
@@ -69,8 +117,8 @@ def compare_simple(
     Returns a very simple textual difference between the two supplied objects.
     """
     if x != y:
-        repr_x = repr(x)
-        repr_y = repr(y)
+        repr_x = safe_repr(x)
+        repr_y = safe_repr(y)
         if repr_x == repr_y:
             if type(x) is not type(y):
                 return compare_with_type(x, y, context)
@@ -82,15 +130,15 @@ def compare_simple(
                                          'attributes ', '.%s')
             if diff_:
                 return diff_
-            return 'Both %s and %s appear as %r, but are not equal!' % (
-                context.x_label or 'x', context.y_label or 'y', repr_x
-            )
+            x_label = context.x_label or 'x'
+            y_label = context.y_label or 'y'
+            return f'Both {x_label} and {y_label} appear as {repr_x!r}, but are not equal!'
         labeled_x = context.label('x', repr_x)
         labeled_y = context.label('y', repr_y)
         if len(repr_x) > newline_threshold or len(repr_y) > newline_threshold:
             return f'not equal:\n{labeled_x}\n{labeled_y}'
         else:
-            return context.label('x', repr_x) + ' != ' + context.label('y', repr_y)
+            return f'{labeled_x} != {labeled_y}'
     return None
 
 
@@ -247,13 +295,15 @@ def compare_sequence(
     if l_x == l_y and i == l_x:
         return None
 
-    return (('sequence not as expected:\n\n' if prefix else '')+
-            'same:\n%s\n\n'
-            '%s:\n%s\n\n'
-            '%s:\n%s') % (pformat(x[:i]),
-                          context.x_label or 'first', pformat(x[i:]),
-                          context.y_label or 'second', pformat(y[i:]),
-                          )
+    header = 'sequence not as expected:\n\n' if prefix else ''
+    same = safe_pformat(x[:i])
+    x_label = context.x_label or 'first'
+    y_label = context.y_label or 'second'
+    return (
+        f'{header}same:\n{same}\n\n'
+        f'{x_label}:\n{safe_pformat(x[i:])}\n\n'
+        f'{y_label}:\n{safe_pformat(y[i:])}'
+    )
 
 
 def compare_generator(x: Iterable, y: Iterable, context: 'CompareContext') -> str | None:
@@ -307,7 +357,7 @@ Item = TypeVar('Item')
 
 
 def sorted_by_repr(sequence: Iterable[Item]) -> List[Item]:
-    return sorted(sequence, key=lambda o: repr(o))
+    return sorted(sequence, key=safe_repr)
 
 
 def _compare_mapping(
@@ -324,11 +374,9 @@ def _compare_mapping(
     diffs = []
     for key in sorted_by_repr(x_keys.intersection(y_keys)):
         if context.different(x[key], y[key], breadcrumb % (key, )):
-            diffs.append('%r: %s != %s' % (
-                key,
-                context.label('x', pformat(x[key])),
-                context.label('y', pformat(y[key])),
-                ))
+            labelled_x = context.label('x', safe_pformat(x[key]))
+            labelled_y = context.label('y', safe_pformat(y[key]))
+            diffs.append(f'{safe_repr(key)}: {labelled_x} != {labelled_y}')
         else:
             same.append(key)
 
@@ -338,34 +386,28 @@ def _compare_mapping(
     if obj_for_class is not_there:
         lines = []
     else:
-        lines = ['%s not as expected:' % obj_for_class.__class__.__name__]
+        lines = [f'{obj_for_class.__class__.__name__} not as expected:']
 
     if same:
         try:
             same = sorted(same)
         except TypeError:
             pass
-        lines.extend(('', '%ssame:' % prefix, repr(same)))
+        lines.extend(('', f'{prefix}same:', safe_repr(same)))
 
     x_label = context.x_label or 'first'
     y_label = context.y_label or 'second'
 
     if x_not_y:
-        lines.extend(('', '%sin %s but not %s:' % (prefix, x_label, y_label)))
+        lines.extend(('', f'{prefix}in {x_label} but not {y_label}:'))
         for key in sorted_by_repr(x_not_y):
-            lines.append('%r: %s' % (
-                key,
-                pformat(x[key])
-                ))
+            lines.append(f'{safe_repr(key)}: {safe_pformat(x[key])}')
     if y_not_x:
-        lines.extend(('', '%sin %s but not %s:' % (prefix, y_label, x_label)))
+        lines.extend(('', f'{prefix}in {y_label} but not {x_label}:'))
         for key in sorted_by_repr(y_not_x):
-            lines.append('%r: %s' % (
-                key,
-                pformat(y[key])
-                ))
+            lines.append(f'{safe_repr(key)}: {safe_pformat(y[key])}')
     if diffs:
-        lines.extend(('', '%sdiffer:' % (prefix or 'values ')))
+        lines.extend(('', f"{prefix or 'values '}differ:"))
         lines.extend(diffs)
     return '\n'.join(lines)
 
@@ -379,19 +421,19 @@ def compare_set(x: set, y: set, context: 'CompareContext') -> str | None:
     y_not_x = y - x
     if not (y_not_x or x_not_y):
         return None
-    lines = ['%s not as expected:' % x.__class__.__name__, '']
+    lines = [f'{x.__class__.__name__} not as expected:', '']
     x_label = context.x_label or 'first'
     y_label = context.y_label or 'second'
     if x_not_y:
         lines.extend((
-            'in %s but not %s:' % (x_label, y_label),
-            pformat(sorted_by_repr(x_not_y)),
+            f'in {x_label} but not {y_label}:',
+            safe_pformat(sorted_by_repr(x_not_y)),
             '',
             ))
     if y_not_x:
         lines.extend((
-            'in %s but not %s:' % (y_label, x_label),
-            pformat(sorted_by_repr(y_not_x)),
+            f'in {y_label} but not {x_label}:',
+            safe_pformat(sorted_by_repr(y_not_x)),
             '',
             ))
     return '\n'.join(lines)+'\n'
@@ -529,7 +571,7 @@ def compare_with_fold(x: datetime, y: datetime, context: 'CompareContext') -> st
 
 
 def _short_repr(obj: Any) -> str:
-    repr_ = repr(obj)
+    repr_ = safe_repr(obj)
     if len(repr_) > 30:
         repr_ = repr_[:30] + '...'
     return repr_

--- a/src/testfixtures/comparison.py
+++ b/src/testfixtures/comparison.py
@@ -275,7 +275,11 @@ class CompareContext:
 
 
 def _resolve_lazy(source: Any) -> str:
-    return str(source() if callable(source) else source)
+    value = source() if callable(source) else source
+    try:
+        return str(value)
+    except Exception:
+        return safe_repr(value)
 
 
 unspecified = singleton('unspecified')
@@ -398,7 +402,7 @@ class StatefulComparison:
         return name
 
     def body(self) -> str:
-        return pformat(self.expected)[1:-1]
+        return safe_pformat(self.expected)[1:-1]
 
     def __repr__(self) -> str:
         name = self.name()
@@ -507,10 +511,10 @@ class Comparison(StatefulComparison):
             # if we're not failed, show what we will expect:
             lines = []
             for k, v in sorted(self.expected_attributes.items()):
-                rv = repr(v)
+                rv = safe_repr(v)
                 if '\n' in rv:
                     rv = indent(rv)
-                lines.append('%s: %s' % (k, rv))
+                lines.append(f'{k}: {rv}')
             return '\n'.join(lines)
         return ''
 
@@ -700,7 +704,7 @@ class MappingComparison(StatefulComparison):
         parts = []
         text_length = 0
         for key, value in self.expected.items():
-            part = repr(key)+': '+pformat(value)
+            part = f'{safe_repr(key)}: {safe_pformat(value)}'
             text_length += len(part)
             parts.append(part)
         if text_length > 60:

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -1,3 +1,4 @@
+import json
 import re
 import uuid
 from abc import ABC
@@ -13,10 +14,14 @@ from uuid import uuid4, UUID
 
 from testfixtures import (
     Comparison as C,
+    MappingComparison,
     Replacer,
+    SequenceComparison,
     ShouldRaise,
     compare,
     generator,
+    safe_pformat,
+    safe_repr,
     singleton,
 )
 from testfixtures.comparers import (
@@ -2482,3 +2487,346 @@ class TestGenericTypes:
             '\n'
             "While comparing .__args__[0]: <class 'int'> != <class 'float'>"
         ))
+
+
+class Broken:
+    # An object whose __repr__ raises on demand.
+    marker = '<unrepresentable tests.test_compare.Broken: ValueError: boom!>'
+
+    def __init__(self, label='broken', exc=None):
+        self.label = label
+        self._exc = ValueError('boom!') if exc is None else exc
+
+    def __repr__(self):
+        raise self._exc
+
+
+class HashableBroken(Broken):
+    # Hashable + comparable so it can be used as a dict key or set member.
+
+    marker = '<unrepresentable tests.test_compare.HashableBroken: ValueError: boom!>'
+
+    def __init__(self, label='broken', exc=None):
+        super().__init__(label, exc)
+
+    def __hash__(self):
+        return hash(self.label)
+
+    def __eq__(self, other):
+        return isinstance(other, HashableBroken) and self.label == other.label
+
+
+class TestSafeHelpers:
+
+    def test_safe_repr_normal_object(self):
+        compare(safe_repr(42), expected='42')
+        compare(safe_repr('hi'), expected="'hi'")
+        compare(safe_repr([1, 2]), expected='[1, 2]')
+
+    def test_safe_repr_broken_object(self):
+        compare(safe_repr(Broken()), expected=Broken.marker)
+
+    def test_safe_repr_other_exception_class(self):
+        compare(
+            safe_repr(Broken(exc=TypeError('nope'))),
+            expected='<unrepresentable tests.test_compare.Broken: TypeError: nope>',
+        )
+
+    def test_safe_repr_list_with_broken_element(self):
+        compare(
+            safe_repr([1, Broken(), 3]),
+            expected=f'[1, {Broken.marker}, 3]',
+        )
+
+    def test_safe_repr_tuple_with_broken_element(self):
+        compare(
+            safe_repr((1, Broken())),
+            expected=f'(1, {Broken.marker})',
+        )
+
+    def test_safe_repr_single_element_tuple_with_broken(self):
+        compare(
+            safe_repr((Broken(),)),
+            expected=f'({Broken.marker},)',
+        )
+
+    def test_safe_repr_dict_with_broken_value(self):
+        compare(
+            safe_repr({'k': Broken()}),
+            expected=f"{{'k': {Broken.marker}}}",
+        )
+
+    def test_safe_repr_dict_with_broken_key(self):
+        compare(
+            safe_repr({HashableBroken('k1'): 'v'}),
+            expected=f"{{{HashableBroken.marker}: 'v'}}",
+        )
+
+    def test_safe_repr_set_with_broken_element(self):
+        compare(
+            safe_repr({HashableBroken('k1')}),
+            expected='{' + HashableBroken.marker + '}',
+        )
+
+    def test_safe_repr_frozenset_with_broken_element(self):
+        compare(
+            safe_repr(frozenset({HashableBroken('k1')})),
+            expected='frozenset({' + HashableBroken.marker + '})',
+        )
+
+    def test_safe_repr_empty_frozenset_subclass_with_broken_repr(self):
+        # repr() of an empty frozenset never fails naturally, so reach the
+        # empty-frozenset fallback via a subclass whose __repr__ raises.
+        class BrokenFrozenSet(frozenset):
+            def __repr__(self):
+                raise ValueError('boom!')
+
+        compare(safe_repr(BrokenFrozenSet()), expected='BrokenFrozenSet')
+
+    def test_safe_repr_empty_set_subclass_with_broken_repr(self):
+        class BrokenSet(set):
+            def __repr__(self):
+                raise ValueError('boom!')
+
+        compare(safe_repr(BrokenSet()), expected='BrokenSet()')
+
+    def test_safe_repr_propagates_keyboard_interrupt(self):
+        class K(KeyboardInterrupt): pass
+
+        with ShouldRaise(K):
+            safe_repr(Broken(exc=K()))
+
+    def test_safe_repr_handles_exception_with_broken_str(self):
+        class BrokenExc(Exception):
+            def __str__(self):
+                raise RuntimeError('inner-fail')
+
+        # When the exception's __str__ raises, the marker still falls back
+        # to just the exception class name without the message.
+        result = safe_repr(Broken(exc=BrokenExc()))
+        compare(
+            result,
+            expected='<unrepresentable tests.test_compare.Broken: BrokenExc>',
+        )
+
+    def test_safe_pformat_normal_object(self):
+        compare(safe_pformat([1, 2, 3]), expected='[1, 2, 3]')
+
+    def test_safe_pformat_falls_back_to_safe_repr(self):
+        compare(
+            safe_pformat([1, Broken(), 3]),
+            expected=f'[1, {Broken.marker}, 3]',
+        )
+
+    def test_safe_pformat_propagates_keyboard_interrupt(self):
+        class K(KeyboardInterrupt): pass
+
+        with ShouldRaise(K):
+            safe_pformat(Broken(exc=K()))
+
+
+class TestSafeRenderingInComparers:
+
+    def test_compare_simple_broken_x(self):
+        check_raises(
+            Broken(), 42,
+            message=(
+                'not equal:\n'
+                f'{Broken.marker}\n'
+                '42'
+            ),
+        )
+
+    def test_compare_simple_broken_y(self):
+        check_raises(
+            42, Broken(),
+            message=(
+                'not equal:\n'
+                '42\n'
+                f'{Broken.marker}'
+            ),
+        )
+
+    def test_compare_sequence_broken_element(self):
+        check_raises(
+            [1, Broken(), 3], [1, Broken(), 3, 4],
+            message=(
+                'sequence not as expected:\n'
+                '\n'
+                'same:\n'
+                f'[1, {Broken.marker}, 3]\n'
+                '\n'
+                'first:\n'
+                '[]\n'
+                '\n'
+                'second:\n'
+                '[4]'
+            ),
+        )
+
+    def test_compare_dict_broken_value_difference(self):
+        check_raises(
+            {'k': Broken()}, {'k': 99},
+            message=(
+                'dict not as expected:\n'
+                '\n'
+                'values differ:\n'
+                f"'k': {Broken.marker} != 99\n"
+                '\n'
+                "While comparing ['k']: not equal:\n"
+                f'{Broken.marker}\n'
+                '99'
+            ),
+        )
+
+    def test_compare_dict_key_only_on_one_side(self):
+        check_raises(
+            {HashableBroken('only-x'): 1},
+            {HashableBroken('only-y'): 2},
+            message=(
+                'dict not as expected:\n'
+                '\n'
+                'in first but not second:\n'
+                f'{HashableBroken.marker}: 1\n'
+                '\n'
+                'in second but not first:\n'
+                f'{HashableBroken.marker}: 2'
+            ),
+        )
+
+    def test_compare_set_broken_element(self):
+        check_raises(
+            {HashableBroken('a'), 1}, {1},
+            message=(
+                'set not as expected:\n'
+                '\n'
+                'in first but not second:\n'
+                f'[{HashableBroken.marker}]\n'
+                '\n'
+            ),
+        )
+
+    def test_compare_with_type_short_repr_broken(self):
+        check_raises(
+            Broken(), 'hello',
+            strict=True,
+            message=(
+                "<unrepresentable tests.test_co... "
+                "(<class 'tests.test_compare.Broken'>) != "
+                "'hello' (<class 'str'>)"
+            ),
+        )
+
+    def test_already_seen_broken_repr(self):
+        broken = Broken()
+        check_raises(
+            [broken, [1, 2, 3]], [broken, broken],
+            strict=True,
+            message=(
+                'sequence not as expected:\n'
+                '\n'
+                'same:\n'
+                f'[{Broken.marker}]\n'
+                '\n'
+                'first:\n'
+                '[[1, 2, 3]]\n'
+                '\n'
+                'second:\n'
+                f'[{Broken.marker}]\n'
+                '\n'
+                "While comparing [1]: [1, 2, 3] (<class 'list'>) != "
+                "<AlreadySeen for <unrepresenta... "
+                "(<class 'testfixtures.comparers.AlreadySeen'>)"
+            ),
+        )
+
+
+class BrokenStr(Broken):
+    # __str__ AND __repr__ raise on demand
+
+    def __str__(self):
+        raise self._exc
+
+
+class TestSafeRenderingInComparison:
+
+    def test_resolve_lazy_prefix_str_raises(self):
+        # prefix is a callable whose return value's __str__ raises;
+        # _resolve_lazy must not crash compare's diff rendering.
+        check_raises(
+            1, 2,
+            prefix=lambda: BrokenStr(),
+            message=(
+                '<unrepresentable tests.test_compare.BrokenStr: ValueError: boom!>: 1 != 2'
+            ),
+        )
+
+    def test_resolve_lazy_suffix_str_raises(self):
+        check_raises(
+            1, 2,
+            suffix=lambda: BrokenStr(),
+            message=(
+                '1 != 2\n'
+                '<unrepresentable tests.test_compare.BrokenStr: ValueError: boom!>'
+            ),
+        )
+
+    def test_comparison_body_broken_attribute_value(self):
+        # Comparison.body is hit when repr() is called on a fresh Comparison
+        # whose comparison hasn't run yet (self.failed empty).
+        class Holder:
+            pass
+
+        compare(
+            repr(C(Holder, attr=Broken())),
+            expected=f'<C:tests.test_compare.Holder>attr: {Broken.marker}</>',
+        )
+
+    def test_mapping_comparison_body_broken_value(self):
+        compare(
+            repr(MappingComparison(k=Broken())),
+            expected=(
+                '<MappingComparison(ordered=False, partial=False)>'
+                f"'k': {Broken.marker}</>"
+            ),
+        )
+
+    def test_sequence_comparison_body_broken_value(self):
+        compare(
+            repr(SequenceComparison(Broken())),
+            expected=(
+                '<SequenceComparison(ordered=True, partial=False)>'
+                f'{Broken.marker},</>'
+            ),
+        )
+
+
+@dataclass(repr=False)
+class JsonReprThing:
+    name: str
+
+    def __repr__(self) -> str:
+        # blow up if we get a Comparison for one of our attributes:
+        return json.dumps(vars(self))
+
+
+class TestSafeRendering:
+
+    def test_json_repr(self):
+        check_raises(
+            expected=[JsonReprThing(name=like(str))],
+            actual=[JsonReprThing(name='hello'), JsonReprThing(name='extra')],
+            message=(
+                'sequence not as expected:\n'
+                '\n'
+                'same:\n'
+                '[<unrepresentable tests.test_compare.JsonReprThing: '
+                'TypeError: Object of type Comparison is not JSON serializable>]\n'
+                '\n'
+                'expected:\n'
+                '[]\n'
+                '\n'
+                'actual:\n'
+                '[{"name": "extra"}]'
+            ),
+        )


### PR DESCRIPTION
This means we now show as much context as possible, even when objects misbehave.