### PR TITLE
Add testfixtures.structlog stub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
             extra: "--extra loguru"
           - python-version: "3.14"
             uv-resolution: "highest"
+            extra: "--extra structlog"
+          - python-version: "3.14"
+            uv-resolution: "highest"
             extra: "--extra twisted --group twisted-dev"
           - python-version: "3.14"
             uv-resolution: "highest"
@@ -94,6 +97,7 @@ jobs:
           - "loguru"
           - "sybil"
           - "mock"
+          - "structlog"
           - "twisted"
     steps:
       - uses: cjw296/python-action/check-distributions@v3

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ The sections below describe the use of the various tools included:
    popen.rst
    django.rst
    loguru.rst
+   structlog.rst
    twisted.rst
    utilities.rst
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -67,6 +67,8 @@ with the version of these packages that your project is using:
 
 - ``[mock-backport]``: See documentation on :ref:`which mock to use <what-mock>`.
 
+- ``[structlog]``: structlog logging framework support. See :doc:`structlog`.
+
 - ``[yaml]``: YAML format support for :class:`~testfixtures.TempDir`. See :ref:`files`.
 
 - ``[toml]``: TOML format writing support for :class:`~testfixtures.TempDir`. See :ref:`files`.

--- a/docs/structlog.rst
+++ b/docs/structlog.rst
@@ -1,0 +1,17 @@
+Testing with structlog
+======================
+
+.. note::
+
+   To ensure you are using compatible versions, install with the ``testfixtures[structlog]`` extra.
+
+.. invisible-code-block: python
+
+    try:
+        import structlog
+    except ImportError:
+        structlog = None
+
+.. skip: start if(structlog is None, reason="No structlog installed")
+
+Helpers for testing code that uses `structlog <https://www.structlog.org/>`_ will live here.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ django = [
 sybil = ["sybil>=10.0.1"]
 mock-backport = ["mock>=4.0.3"]
 loguru = ["loguru>=0.7.3"]
+structlog = ["structlog>=24.1"]
 twisted = ["twisted>=22.1"]
 yaml = ["pyyaml>=6.0.3"]
 toml = ["tomlkit>=0.10.0"]

--- a/src/testfixtures/structlog.py
+++ b/src/testfixtures/structlog.py
@@ -1,0 +1,4 @@
+"""
+Tools for helping to test applications that use structlog.
+"""
+import structlog as structlog

--- a/tests/test_structlog.py
+++ b/tests/test_structlog.py
@@ -1,0 +1,10 @@
+import pytest
+
+pytest.importorskip("structlog")
+
+import testfixtures.structlog
+from testfixtures import compare
+
+
+def test_importable():
+    compare(testfixtures.structlog.structlog.__name__, expected="structlog")


### PR DESCRIPTION
## Summary
- Wires up the `structlog` optional extra so future structlog helpers have a place to land.
- Adds `src/testfixtures/structlog.py` (just re-exports the package), `tests/test_structlog.py` (skip-if-not-installed), `docs/structlog.rst` stub page, install-instructions bullet, `pyproject.toml` extra, and CI matrix entries (per-extra tests + check-package).
- No functionality yet — opening as draft to verify CI is happy with the stub wiring before any real code lands.

## Test plan
- [x] `./happy.sh` green locally
- [ ] CI green on the per-extra `--extra structlog` matrix entry
- [ ] CI green on the `check-package` matrix entry for `structlog`