### PR TITLE
`ignore_eq` per type

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -49,6 +49,7 @@ testfixtures.comparison
 .. autofunction:: testfixtures.comparison.register
 
 .. autoclass:: testfixtures.comparison.CompareContext
+   :members:
 
 testfixtures.comparers
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/comparing.rst
+++ b/docs/comparing.rst
@@ -527,8 +527,8 @@ don't compare as equal.
   from testfixtures.comparison import _registry, Registry
   from testfixtures.comparers import compare_sequence
   from testfixtures import Replacer
-  r = Replacer()
-  r.replace('testfixtures.comparison._registry', Registry.initial({
+  registry_replacer = Replacer()
+  registry_replacer('testfixtures.comparison._registry', Registry.initial({
       list: compare_sequence
   }))
 
@@ -613,7 +613,7 @@ AssertionError: MyObject named 'foo' != MyObject named 'bar'
 
 .. invisible-code-block: python
 
-  r.restore()
+  registry_replacer.restore()
 
 A full list of the available comparers included can be found below the
 API documentation for :func:`compare`. These make good candidates for
@@ -801,9 +801,17 @@ or :exc:`SystemExit`, and substitute any failures with a marker.
 Ignoring ``__eq__``
 ~~~~~~~~~~~~~~~~~~~
 
-Some objects, such as those from the :doc:`Django ORM <django>`, have pretty broken
-implementations of ``__eq__``. Since :func:`compare` normally relies on this,
-it can result in objects appearing to be equal when they are not.
+.. warning::
+  If you find yourself in situation where objects incorrectly express equality, be very careful to
+  ensure that you see any tests you implement failing due to inequality before you assume that
+  anything described in this section is working as you expect.
+  Equality checking is complex, and there are gotchas lurking
+  with container types and objects on either side of an equality check implementing ``__eq__``.
+
+Some objects, such as those from the :doc:`Django ORM <django>`, make unfortunate choices in their
+implementations of ``__eq__`` when it comes to checking that objects have identical attributes.
+Since :func:`compare` normally relies on this, it can result in objects appearing to be equal when
+they are not.
 
 Take this class, for example:
 
@@ -821,20 +829,91 @@ If we compare normally, we erroneously understand the objects to be equal:
 
 >>> compare(actual=OrmObj(1), expected=OrmObj(2))
 
-In order to get a sane comparison, we need to both supply a custom comparer
-as described above, and use the ``ignore_eq`` parameter:
+In order to get a correct comparison, we need to use the ``ignore_eq`` parameter:
+
+>>> compare(actual=OrmObj(1), expected=OrmObj(2), ignore_eq=OrmObj)
+Traceback (most recent call last):
+...
+AssertionError: OrmObj not as expected:
+<BLANKLINE>
+attributes differ:
+'a': 2 (expected) != 1 (actual)
+
+``ignore_eq`` accepts a single type, an iterable of types, or ``True`` to
+skip ``__eq__`` for *every* object during the comparison.
+
+If a particular type and all of its sublclasses are always problematic, you can register it once
+globally so callers don't need to remember the ``ignore_eq=`` argument:
+
+.. invisible-code-block: python
+
+  registry_replacer = Replacer()
+  registry_replacer('testfixtures.comparison._registry', _registry.copy())
+
 
 .. code-block:: python
 
-  def compare_orm_obj(x, y, context):
-      if x.a != y.a:
-          return 'OrmObj: %s != %s' % (x.a, y.a)
+  from testfixtures import register
 
->>> compare(actual=OrmObj(1), expected=OrmObj(2),
-...         comparers={OrmObj: compare_orm_obj}, ignore_eq=True)
+  register(OrmObj, ignore_eq=True)
+
+.. invisible-code-block: python
+
+   registry_replacer.restore()
+
+Custom containers and ``ignore_eq``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When you pass a type to ``ignore_eq``, :func:`compare` also has to
+ignore the ``__eq__`` of any containers that might contain the type passed to ``ignore_eq``.
+This is handled for standard container types and their subclasses, specifically :class:`list`,
+:class:`tuple`, :class:`dict`, :class:`set`, and :class:`frozenset`.
+
+For an custom container or wrapper types that implement ``__eq__`` and don't subclass one
+of these standard container types, *and* which can contain instance of a type for which you'd like
+to ``ignore_eq``, you will find that ``ignore_eq`` for that type alone is not sufficient.
+
+For example, consider this container type:
+
+.. code-block:: python
+
+  class OrmObjBox:
+      def __init__(self, *items: OrmObj):
+          self.items = list(items)
+      def __eq__(self, other: "OrmObjBox") -> bool:
+          return self.items == other.items
+
+If we only pass :class:`!OrmObj` to ``ignore_eq``, the :class:`!OrmObjBox` instances will still
+erroneously appear to be equal:
+
+>>> compare(OrmObjBox(OrmObj(1)), OrmObjBox(OrmObj(2)), ignore_eq=OrmObj)
+
+To successfully ignore the ``__eq__`` of :class:`!OrmObj`, we need to pass both the type and
+any custom container or wrapper types to ``ignore_eq``:
+
+>>> compare(OrmObjBox(OrmObj(1)), OrmObjBox(OrmObj(2)), ignore_eq=[OrmObj, OrmObjBox])
 Traceback (most recent call last):
 ...
-AssertionError: OrmObj: 2 != 1
+AssertionError: OrmObjBox not as expected:
+<BLANKLINE>
+attributes differ:
+'items': [OrmObj: 1] != [OrmObj: 2]
+<BLANKLINE>
+While comparing .items: sequence not as expected:
+<BLANKLINE>
+same:
+[]
+<BLANKLINE>
+first:
+[OrmObj: 1]
+<BLANKLINE>
+second:
+[OrmObj: 2]
+<BLANKLINE>
+While comparing .items[0]: OrmObj not as expected:
+<BLANKLINE>
+attributes differ:
+'a': 1 != 2
 
 .. _strict-comparison:
 

--- a/docs/comparing.rst
+++ b/docs/comparing.rst
@@ -587,6 +587,9 @@ implement your own comparers.
   A comparer should always return some text when it considers
   the two objects it is comparing to be different.
 
+
+.. _custom-comparer-different:
+
 Handing off comparison
 ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/comparing.rst
+++ b/docs/comparing.rst
@@ -524,13 +524,9 @@ don't compare as equal.
 
 .. invisible-code-block: python
 
-  from testfixtures.comparison import _registry, Registry
+  from testfixtures.comparison import Registry
   from testfixtures.comparers import compare_sequence
-  from testfixtures import Replacer
-  registry_replacer = Replacer()
-  registry_replacer('testfixtures.comparison._registry', Registry.initial({
-      list: compare_sequence
-  }))
+  registry = Registry.initial({list: compare_sequence}).install()
 
 As an example, suppose you have a class whose instances have a
 timestamp and a name as attributes, but you'd like to ignore the
@@ -613,7 +609,7 @@ AssertionError: MyObject named 'foo' != MyObject named 'bar'
 
 .. invisible-code-block: python
 
-  registry_replacer.restore()
+  registry.uninstall()
 
 A full list of the available comparers included can be found below the
 API documentation for :func:`compare`. These make good candidates for
@@ -702,9 +698,7 @@ comparer could be implemented and registered as follows:
 
 .. invisible-code-block: python
 
-  from testfixtures.comparison import _registry
-  r = Replacer()
-  r.replace('testfixtures.comparison._registry', _registry.overlay_with({}))
+  registry = Registry.initial().install()
 
 .. code-block:: python
 
@@ -781,7 +775,7 @@ attributes to ignore:
 
 .. invisible-code-block: python
 
-  r.restore()
+  registry.uninstall()
 
 Rendering objects safely in custom comparers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -847,8 +841,7 @@ globally so callers don't need to remember the ``ignore_eq=`` argument:
 
 .. invisible-code-block: python
 
-  registry_replacer = Replacer()
-  registry_replacer('testfixtures.comparison._registry', _registry.copy())
+  registry = Registry.initial().install()
 
 
 .. code-block:: python
@@ -859,7 +852,7 @@ globally so callers don't need to remember the ``ignore_eq=`` argument:
 
 .. invisible-code-block: python
 
-   registry_replacer.restore()
+   registry.uninstall()
 
 Custom containers and ``ignore_eq``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/comparing.rst
+++ b/docs/comparing.rst
@@ -466,6 +466,45 @@ While comparing [1]['text']:
 This also applies to any comparers you have provided, as can be seen
 in the next section.
 
+Preventing infinite recursion
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If an object refers back to itself — directly, or via something it
+contains — the recursive comparison used by :func:`compare` would loop forever.
+To avoid this, if an object is seen more than once during a comparison, it is
+wrapped with an :class:`~testfixtures.comparers.AlreadySeen` marker
+rather than being compared again.
+
+When that happens *and* a difference is being reported anyway, the
+marker becomes visible in the output:
+
+>>> ouroboros1 = {}
+>>> ouroboros1['ouroboros'] = ouroboros1
+>>> ouroboros2 = {}
+>>> ouroboros2['ouroboros'] = ouroboros2
+>>> compare({1: ouroboros1, 2: 'foo'}, {1: ouroboros2, 2: ouroboros2})
+Traceback (most recent call last):
+ ...
+AssertionError: dict not as expected:
+<BLANKLINE>
+same:
+[1]
+<BLANKLINE>
+values differ:
+2: 'foo' != {'ouroboros': <Recursion on dict with id=...>}
+<BLANKLINE>
+While comparing [2]: not equal:
+'foo'
+<AlreadySeen for {'ouroboros': {...}} at [1] with id ...>
+
+The ``at [1]`` part of the marker is the path where that object was
+first encountered, so you can trace the cycle back to its origin.
+
+If the same object appears at the same position in both sides of a
+comparison :func:`compare` treats it as equal by identity without calling its ``__eq__``.
+No marker is visible in that case, and an :ref:`unhelpful <ignore-eq>` ``__eq__`` cannot
+cause a spurious difference.
+
 .. _comparer-register:
 
 Providing your own comparers

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ exclude_trees = ['_build']
 pygments_style = 'sphinx'
 
 # Type hints
-autodoc_typehints = 'description'
+autodoc_typehints = 'both'
 autodoc_typehints_description_target = "documented"
 
 # Options for HTML output

--- a/docs/django.rst
+++ b/docs/django.rst
@@ -11,6 +11,8 @@ Testing with Django
       import django
   except ImportError:
       django = None
+  else:
+      from tests.test_django.models import SampleModel
 
 .. skip: start if(django is None, reason="No django installed")
 
@@ -18,34 +20,20 @@ Django's ORM has an unfortunate implementation choice of considering
 :class:`~django.db.models.Model` instances to be identical as long as their
 primary keys are the same:
 
->>> from tests.test_django.models import SampleModel
+.. literalinclude:: ../tests/test_django/models.py
+   :pyobject: SampleModel
+
 >>> SampleModel(id=1, value=1) == SampleModel(id=1, value=2)
 True
 
-To work around this, :mod:`testfixtures.django` :ref:`registers <comparer-register>`
-a :func:`comparer <testfixtures.django.compare_model>` for the django
-:class:`~django.db.models.Model` class. However, for this to work,
-``ignore_eq=True`` must be passed:
+To work around this, when Django is installed, a
+:func:`comparer <testfixtures.django.compare_model>` for the
+:class:`~django.db.models.Model` class is automatically
+:ref:`registered <comparer-register>` with ``ignore_eq=True``, so
+:func:`~testfixtures.compare` does the right thing:
 
 >>> from testfixtures import compare
->>> import testfixtures.django # to register the comparer...
->>> compare(SampleModel(id=1, value=1), SampleModel(id=1, value=2),
-...         ignore_eq=True)
-Traceback (most recent call last):
- ...
-AssertionError: SampleModel not as expected:
-<BLANKLINE>
-same:
-['id']
-<BLANKLINE>
-values differ:
-'value': 1 != 2
-
-Since the above can quickly become cumbersome, a django-specific version
-of :func:`~testfixtures.compare` that ignores ``__eq__`` by default is provided:
-
->>> from testfixtures.django import compare as django_compare
->>> django_compare(SampleModel(id=1, value=1), SampleModel(id=1, value=2))
+>>> compare(SampleModel(id=1, value=1), SampleModel(id=1, value=2))
 Traceback (most recent call last):
  ...
 AssertionError: SampleModel not as expected:
@@ -61,10 +49,10 @@ Ignoring fields
 
 It may also be that you want to ignore fields over which you have no control
 and cannot easily mock, such as created or modified times. For this, you
-can use the `ignore_fields` option:
+can use the ``ignore_fields`` option:
 
 >>> compare(SampleModel(id=1, value=1), SampleModel(id=1, value=2),
-...         ignore_eq=True, ignore_fields=['value'])
+...         ignore_fields=['value'])
 
 
 Comparing non-editable fields
@@ -72,13 +60,13 @@ Comparing non-editable fields
 
 By default, non-editable fields are ignored:
 
->>> django_compare(SampleModel(not_editable=1), SampleModel(not_editable=2))
+>>> compare(SampleModel(not_editable=1), SampleModel(not_editable=2))
 
 If you wish to include these fields in the comparison, pass the
 ``non_editable_fields`` option:
 
->>> django_compare(SampleModel(not_editable=1), SampleModel(not_editable=2),
-...                non_editable_fields=True)
+>>> compare(SampleModel(not_editable=1), SampleModel(not_editable=2),
+...         non_editable_fields=True)
 Traceback (most recent call last):
  ...
 AssertionError: SampleModel not as expected:

--- a/src/testfixtures/__init__.py
+++ b/src/testfixtures/__init__.py
@@ -16,7 +16,7 @@ from testfixtures.comparers import diff, safe_pformat, safe_repr
 from testfixtures.comparison import (
     Comparison, StringComparison, RoundComparison, compare, RangeComparison,
     SequenceComparison, Subset, Permutation, MappingComparison, like, sequence,
-    contains, unordered
+    contains, unordered, register
 )
 from testfixtures.datetime import mock_datetime, mock_date, mock_time
 from testfixtures.logcapture import LogCapture, log_capture, LoggingSource
@@ -74,6 +74,7 @@ __all__ = [
     'mock_datetime',
     'mock_time',
     'not_there',
+    'register',
     'replace',
     'replace_in_environ',
     'replace_on_class',

--- a/src/testfixtures/comparers.py
+++ b/src/testfixtures/comparers.py
@@ -270,7 +270,7 @@ def compare_object(
     y_attrs = _extract_attrs(y, _attrs_to_ignore(ignore_attributes, y))
     if x_attrs is None or y_attrs is None or not (x_attrs and y_attrs):
         return compare_simple(x, y, context)
-    if not context.simple_equals(x_attrs, y_attrs):
+    if not context.qualified_equals(x_attrs, y_attrs):
         return _compare_mapping(x_attrs, y_attrs, context, x,
                                 'attributes ', '.%s')
     return None
@@ -347,7 +347,7 @@ def compare_generator(x: Iterable, y: Iterable, context: 'CompareContext') -> st
     x = tuple(x)
     y = tuple(y)
 
-    if context.simple_equals(x, y):
+    if context.qualified_equals(x, y):
         return None
 
     return compare_sequence(x, y, context)

--- a/src/testfixtures/comparers.py
+++ b/src/testfixtures/comparers.py
@@ -23,6 +23,35 @@ if TYPE_CHECKING:
     from .comparison import CompareContext
 
 
+__all__ = [
+    'AlreadySeen',
+    'compare_bytes',
+    'compare_call',
+    'compare_dict',
+    'compare_exception',
+    'compare_exception_group',
+    'compare_generator',
+    'compare_object',
+    'compare_partial',
+    'compare_path',
+    'compare_sequence',
+    'compare_set',
+    'compare_simple',
+    'compare_text',
+    'compare_tuple',
+    'compare_with_fold',
+    'compare_with_type',
+    'diff',
+    'merge_ignored_attributes',
+    'safe_pformat',
+    'safe_repr',
+    'sorted_by_repr',
+    'split_repr',
+    'strip_blank_lines',
+    'trailing_whitespace_re',
+]
+
+
 def safe_repr(obj: Any) -> str:
     """
     A fault-tolerant version of :func:`repr`.

--- a/src/testfixtures/comparison.py
+++ b/src/testfixtures/comparison.py
@@ -1,6 +1,6 @@
 import re
 from collections import OrderedDict
-from collections.abc import Iterable as IterableABC
+from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime, time
 from decimal import Decimal
@@ -17,7 +17,6 @@ from typing import (
     List,
     Mapping,
     Callable,
-    Iterable,
     cast,
     overload,
     Self,
@@ -68,7 +67,7 @@ class Registry:
                 return comparer
 
         # fallback for iterables
-        if ((isinstance(x, IterableABC) and isinstance(y, IterableABC)) and not
+        if ((isinstance(x, Iterable) and isinstance(y, Iterable)) and not
             (isinstance(x, _UNSAFE_ITERABLES) or
              isinstance(y, _UNSAFE_ITERABLES))):
             return compare_generator

--- a/src/testfixtures/comparison.py
+++ b/src/testfixtures/comparison.py
@@ -17,6 +17,7 @@ from typing import (
     List,
     Mapping,
     Callable,
+    Iterable,
     cast,
     overload,
     Self,
@@ -37,6 +38,11 @@ from .comparers import _compare_mapping, _extract_attrs
 # Some common types that are immutable, for optimisation purposes within CompareContext
 IMMUTABLE_TYPEs = str, bytes, int, float, tuple, type(None)
 
+# Container types whose `__eq__` delegates to their elements. When per-type
+# ignore_eq is in play, we can't trust `x == y` on these because nested
+# instances of an ignored type would silently leak through.
+CONTAINER_TYPES = list, tuple, dict, set, frozenset
+
 
 Comparer = Callable[[Any, Any, 'CompareContext'], str | None]
 Comparers: TypeAlias = dict[type, Comparer]
@@ -49,6 +55,7 @@ class Registry:
     comparers: dict[type, Comparer]
     all_option_names: set[str]
     options_for: dict[Comparer, set[str]]
+    ignore_eq_types: set[type]
 
     @staticmethod
     def _shared_mro(x: Any, y: Any) -> Iterable[type]:
@@ -89,7 +96,8 @@ class Registry:
         registry = cls(
             comparers={},
             all_option_names = {'ignore_attributes'},
-            options_for = {compare_object: {'ignore_attributes'}}
+            options_for = {compare_object: {'ignore_attributes'}},
+            ignore_eq_types = set(),
         )
         for name, value in comparers.items():
             registry[name] = value
@@ -99,7 +107,8 @@ class Registry:
         return type(self)(
             comparers=self.comparers.copy(),
             all_option_names = self.all_option_names.copy(),
-            options_for = self.options_for.copy()
+            options_for = self.options_for.copy(),
+            ignore_eq_types = self.ignore_eq_types.copy(),
         )
 
     def overlay_with(self, comparers: Comparers) -> Self:
@@ -131,13 +140,37 @@ _registry = Registry.initial({
 })
 
 
-def register(type_: type, comparer: Comparer) -> None:
+@overload
+def register(type_: type, comparer: Comparer) -> None: ...
+@overload
+def register(type_: type, comparer: Comparer, *, ignore_eq: bool) -> None: ...
+@overload
+def register(type_: type, *, ignore_eq: Literal[True]) -> None: ...
+
+
+def register(
+    type_: type,
+    comparer: Comparer | None = None,
+    *,
+    ignore_eq: bool = False,
+) -> None:
     """
-    Register the supplied comparer for the specified type.
+    Register the supplied comparer for the specified type, and/or mark the
+    type as one whose ``__eq__`` should be ignored during comparison.
+
+    At least one of ``comparer`` or ``ignore_eq=True`` must be supplied.
+
     This registration is global and will be in effect from the point
     this function is called until the end of the current process.
     """
-    _registry[type_] = comparer
+    if comparer is None and not ignore_eq:
+        raise TypeError(
+            "register() requires either a comparer or ignore_eq=True"
+        )
+    if comparer is not None:
+        _registry[type_] = comparer
+    if ignore_eq:
+        _registry.ignore_eq_types.add(type_)
 
 
 class CompareContext:
@@ -152,7 +185,7 @@ class CompareContext:
             y_label: str | None,
             recursive: bool = True,
             strict: bool = False,
-            ignore_eq: bool = False,
+            ignore_eq: bool | type | Iterable[type] = False,
             comparers: Comparers | None = None,
             options: dict[str, Any] | None = None,
     ):
@@ -167,7 +200,16 @@ class CompareContext:
         self.y_label = y_label
         self.recursive: bool = recursive
         self.strict: bool = strict
-        self.ignore_eq: bool = ignore_eq
+        self.ignore_eq_all: bool = False
+        self.ignore_eq_types: set[type] = set(self._registry.ignore_eq_types)
+        if ignore_eq is True:
+            self.ignore_eq_all = True
+        elif ignore_eq is False:
+            pass
+        elif isinstance(ignore_eq, type):
+            self.ignore_eq_types.add(ignore_eq)
+        else:
+            self.ignore_eq_types.update(ignore_eq)
         self.options: dict[str, Any] = options or {}
         self.message: str = ''
         self.breadcrumbs: List[str] = []
@@ -221,8 +263,36 @@ class CompareContext:
             self._seen[id_] = breadcrumb
             return obj
 
-    def simple_equals(self, x: Any, y: Any) -> bool:
-        return not (self.strict or self.ignore_eq) and x == y
+    def qualified_equals(self, x: Any, y: Any) -> bool:
+        """
+        Determines if two objects are equal, taking ``strict``, ``ignore_eq`` and instances
+        of :class:`~testfixtures.comparers.AlreadySeen` into account.
+        """
+        pair = x, y
+        # When either side is an AlreadySeen wrapper for the other (same
+        # underlying id), it's the same object we already handled —
+        # equal by identity. Skipping __eq__ here keeps that guarantee
+        # when __eq__ is broken, strict about unknown operands, or being
+        # bypassed via ignore_eq.
+        if any(type(o) is AlreadySeen for o in pair):
+            a, b = (o.id if type(o) is AlreadySeen else id(o) for o in pair)
+            if a == b:
+                return True
+        # AlreadySeen.__eq__ delegates to the wrapped object, so let
+        # normal equality run when the wrapper is on the right.
+        if type(y) is AlreadySeen:
+            return x == y
+        if self.strict or self.ignore_eq_all:
+            return False
+        # Containers delegate __eq__ to their elements, so when any
+        # ignored type is in play we must block container == as well.
+        types = self.ignore_eq_types
+        if types and any(
+            isinstance(o, CONTAINER_TYPES) or not types.isdisjoint(type(o).__mro__)
+            for o in pair
+        ):
+            return False
+        return x == y
 
     def call(self, comparer: Comparer, x: Any, y: Any) -> str | None:
         kw = {}
@@ -250,12 +320,11 @@ class CompareContext:
         current_message = ''
         try:
 
-            if type(y) is AlreadySeen or not (self.strict or self.ignore_eq):
-                try:
-                    if x == y:
-                        return False
-                except RecursionError:
-                    pass
+            try:
+                if self.qualified_equals(x, y):
+                    return False
+            except RecursionError:
+                pass
 
             comparer: Comparer = self._registry.lookup(x, y, self.strict)
 
@@ -304,7 +373,7 @@ def compare(
         raises: bool = True,
         recursive: bool = True,
         strict: bool = False,
-        ignore_eq: bool = False,
+        ignore_eq: bool | type | Iterable[type] = False,
         comparers: Comparers | None = None,
         **options: Any
 ) -> str | None:
@@ -350,11 +419,15 @@ def compare(
     :param strict: If ``True``, objects will only compare equal if they are
                    of the same type as well as being equal.
 
-    :param ignore_eq: If ``True``, object equality, which relies on ``__eq__``
-                      being correctly implemented, will not be used.
-                      Instead, comparers will be looked up and used
-                      and, if no suitable comparer is found, objects will
-                      be considered equal if their hash is equal.
+    :param ignore_eq: Controls when ``__eq__`` is skipped in favour of a
+                      registered comparer (or the hash-equality fallback):
+
+                      * ``True`` — skip ``__eq__`` for *every* object.
+                      * ``False`` (default) — honour ``__eq__`` except for
+                        types registered with ``ignore_eq=True``.
+                      * a type — also skip ``__eq__`` whenever an instance of
+                        that type is on either side of a comparison.
+                      * an iterable of types — as above, for each type.
 
     :param comparers: If supplied, should be a dictionary mapping
                       types to comparer functions for those types. These will

--- a/src/testfixtures/comparison.py
+++ b/src/testfixtures/comparison.py
@@ -1,6 +1,7 @@
 import re
 from collections import OrderedDict
 from collections.abc import Iterable
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, time
 from decimal import Decimal
@@ -17,11 +18,12 @@ from typing import (
     List,
     Mapping,
     Callable,
-    Iterable,
     cast,
     overload,
     Self,
-    TypeAlias, Literal,
+    TypeAlias,
+    Literal,
+    Iterator,
 )
 from typing import _GenericAlias as GenericAlias  # type: ignore[attr-defined]
 
@@ -49,6 +51,27 @@ Comparers: TypeAlias = dict[type, Comparer]
 
 _UNSAFE_ITERABLES = str, bytes, dict, GenericAlias
 
+DEFAULT_COMPARERS: Comparers = {
+    dict: compare_dict,
+    set: compare_set,
+    list: compare_sequence,
+    tuple: compare_tuple,
+    str: compare_text,
+    bytes: compare_bytes,
+    int: compare_simple,
+    float: compare_simple,
+    Decimal: compare_simple,
+    GeneratorType: compare_generator,
+    mock_call.__class__: compare_call,
+    unittest_mock_call.__class__: compare_call,
+    BaseException: compare_exception,
+    BaseExceptionGroup: compare_exception_group,
+    partial_type: compare_partial,
+    Path: compare_path,
+    datetime: compare_with_fold,
+    time: compare_with_fold,
+}
+
 
 @dataclass
 class Registry:
@@ -56,6 +79,7 @@ class Registry:
     all_option_names: set[str]
     options_for: dict[Comparer, set[str]]
     ignore_eq_types: set[type]
+    original: "Registry | None" = None
 
     @staticmethod
     def _shared_mro(x: Any, y: Any) -> Iterable[type]:
@@ -92,14 +116,14 @@ class Registry:
         self.comparers[key] = value
 
     @classmethod
-    def initial(cls, comparers: Comparers) -> Self:
+    def initial(cls, comparers: Comparers | None = None) -> Self:
         registry = cls(
             comparers={},
             all_option_names = {'ignore_attributes'},
             options_for = {compare_object: {'ignore_attributes'}},
             ignore_eq_types = set(),
         )
-        for name, value in comparers.items():
+        for name, value in (DEFAULT_COMPARERS if comparers is None else comparers).items():
             registry[name] = value
         return registry
 
@@ -117,27 +141,29 @@ class Registry:
             registry[name] = value
         return registry
 
+    def install(self) -> Self:
+        global _registry
+        self.original = _registry
+        _registry = self
+        return self
 
-_registry = Registry.initial({
-    dict: compare_dict,
-    set: compare_set,
-    list: compare_sequence,
-    tuple: compare_tuple,
-    str: compare_text,
-    bytes: compare_bytes,
-    int: compare_simple,
-    float: compare_simple,
-    Decimal: compare_simple,
-    GeneratorType: compare_generator,
-    mock_call.__class__: compare_call,
-    unittest_mock_call.__class__: compare_call,
-    BaseException: compare_exception,
-    BaseExceptionGroup: compare_exception_group,
-    partial_type: compare_partial,
-    Path: compare_path,
-    datetime: compare_with_fold,
-    time: compare_with_fold,
-})
+    def uninstall(self) -> None:
+        global _registry
+        assert self.original is not None, "uninstall() called without install()"
+        _registry = self.original
+        del self.original
+
+_registry = Registry.initial()
+
+
+@contextmanager
+def registry(comparers: Comparers | None = None) -> Iterator[Registry]:
+    _registry = Registry.initial(comparers)
+    _registry.install()
+    try:
+        yield _registry
+    finally:
+        _registry.uninstall()
 
 
 @overload

--- a/src/testfixtures/comparison.py
+++ b/src/testfixtures/comparison.py
@@ -45,11 +45,13 @@ IMMUTABLE_TYPEs = str, bytes, int, float, tuple, type(None)
 # instances of an ignored type would silently leak through.
 CONTAINER_TYPES = list, tuple, dict, set, frozenset
 
+# Things that are iterable, but should not be treated as such.
+UNSAFE_ITERABLES = str, bytes, dict, GenericAlias
+
 
 Comparer = Callable[[Any, Any, 'CompareContext'], str | None]
 Comparers: TypeAlias = dict[type, Comparer]
 
-_UNSAFE_ITERABLES = str, bytes, dict, GenericAlias
 
 DEFAULT_COMPARERS: Comparers = {
     dict: compare_dict,
@@ -99,8 +101,8 @@ class Registry:
 
         # fallback for iterables
         if ((isinstance(x, Iterable) and isinstance(y, Iterable)) and not
-            (isinstance(x, _UNSAFE_ITERABLES) or
-             isinstance(y, _UNSAFE_ITERABLES))):
+            (isinstance(x, UNSAFE_ITERABLES) or
+             isinstance(y, UNSAFE_ITERABLES))):
             return compare_generator
 
         # special handling for Comparisons:

--- a/src/testfixtures/comparison.py
+++ b/src/testfixtures/comparison.py
@@ -1109,3 +1109,12 @@ def unordered(
     return SequenceComparison(  # type: ignore[return-value]
         *items, ordered=False, partial=False, recursive=True
     )
+
+
+try:
+    from django.db.models import Model
+    from .django import compare_model
+except ImportError:
+    pass
+else:
+    register(Model, compare_model, ignore_eq=True)

--- a/src/testfixtures/comparison.py
+++ b/src/testfixtures/comparison.py
@@ -20,7 +20,7 @@ from typing import (
     cast,
     overload,
     Self,
-    TypeAlias,
+    TypeAlias, Literal,
 )
 from typing import _GenericAlias as GenericAlias  # type: ignore[attr-defined]
 
@@ -195,7 +195,10 @@ class CompareContext:
 
         return possible
 
-    def label(self, side: str, value: Any) -> str:
+    def label(self, side: Literal["x", "y"], value: Any) -> str:
+        """
+        Generate a labelled representation of the value for one side of a comparison.
+        """
         r = str(value)
         label = getattr(self, side+'_label')
         if label:
@@ -232,6 +235,10 @@ class CompareContext:
         return comparer(x, y, self, **kw)
 
     def different(self, x: Any, y: Any, breadcrumb: str) -> bool | str | None:
+        """
+        Comparers can call this method to :ref:`hand off <custom-comparer-different>`
+        comparison of elements within the objects they are currently comparing.
+        """
 
         x = self._break_loops(x, breadcrumb)
         y = self._break_loops(y, breadcrumb)

--- a/src/testfixtures/django.py
+++ b/src/testfixtures/django.py
@@ -1,15 +1,11 @@
-from typing import Any, Sequence, Iterable
+from typing import TYPE_CHECKING, Any, Iterable, Sequence
 
 from django.db.models import Model, Field
 
-from . import compare as base_compare
 from .comparers import _compare_mapping
-from .comparison import (
-    register,
-    CompareContext,
-    unspecified,
-    Comparers,
-)
+
+if TYPE_CHECKING:
+    from .comparison import CompareContext
 
 
 def instance_fields(instance: Model) -> Iterable[Field]:
@@ -43,7 +39,7 @@ def model_to_dict(
 def compare_model(
         x: Model,
         y: Model,
-        context: CompareContext,
+        context: 'CompareContext',
         ignore_fields: Sequence[str] = (),
         non_editable_fields: bool = False,
 ) -> str | None:
@@ -66,47 +62,3 @@ def compare_model(
     args.append(context)
     args.append(x)
     return _compare_mapping(*args)
-
-
-register(Model, compare_model)
-
-
-def compare(
-        *args: Any,
-        x: Any = unspecified,
-        y: Any = unspecified,
-        expected: Any = unspecified,
-        actual: Any = unspecified,
-        prefix: str | None = None,
-        suffix: str | None = None,
-        x_label: str | None = None,
-        y_label: str | None = None,
-        raises: bool = True,
-        recursive: bool = True,
-        strict: bool = False,
-        ignore_eq: bool = True,
-        comparers: Comparers | None = None,
-        **options: Any
-) -> str | None:
-    """
-    This is identical to :func:`~testfixtures.compare`, but with ``ignore=True``
-    automatically set to make comparing django :class:`~django.db.models.Model`
-    instances easier.
-    """
-    return base_compare(
-        *args,
-        x=x,
-        y=y,
-        expected=expected,
-        actual=actual,
-        prefix=prefix,
-        suffix=suffix,
-        x_label=x_label,
-        y_label=y_label,
-        raises=raises,
-        recursive=recursive,
-        strict=strict,
-        ignore_eq=ignore_eq,
-        comparers=comparers,
-        **options
-    )

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -15,6 +15,7 @@ from uuid import uuid4, UUID
 from testfixtures import (
     Comparison as C,
     MappingComparison,
+    Replace,
     Replacer,
     SequenceComparison,
     ShouldRaise,
@@ -30,7 +31,7 @@ from testfixtures.comparers import (
     compare_text,
     merge_ignored_attributes,
 )
-from testfixtures.comparison import Registry, like
+from testfixtures.comparison import Registry, _registry, like, register
 from testfixtures.compat import PY_312_PLUS
 from testfixtures.mock import Mock, call
 from testfixtures.shouldraise import ShouldAssert
@@ -1560,6 +1561,281 @@ b
             actual=query_set(),
             ignore_eq=True
         )
+
+    def test_django_orm_is_horrible_type(self):
+
+        assert self.OrmObj(1) == self.OrmObj(2)
+
+        def query_set():
+            yield self.OrmObj(1)
+            yield self.OrmObj(2)
+
+        self.check_raises(
+            message=(
+                "sequence not as expected:\n"
+                "\n"
+                "same:\n"
+                "(OrmObj: 1,)\n"
+                "\n"
+                "expected:\n"
+                "(OrmObj: 3,)\n"
+                "\n"
+                "actual:\n"
+                "(OrmObj: 2,)\n"
+                '\n'
+                'While comparing [1]: OrmObj not as expected:\n'
+                '\n'
+                'attributes differ:\n'
+                "'a': 3 (expected) != 2 (actual)"
+            ),
+            expected=[self.OrmObj(1), self.OrmObj(3)],
+            actual=query_set(),
+            ignore_eq=self.OrmObj
+        )
+
+    def test_django_orm_is_horrible_iterable(self):
+
+        assert self.OrmObj(1) == self.OrmObj(2)
+
+        def query_set():
+            yield self.OrmObj(1)
+            yield self.OrmObj(2)
+
+        self.check_raises(
+            message=(
+                "sequence not as expected:\n"
+                "\n"
+                "same:\n"
+                "(OrmObj: 1,)\n"
+                "\n"
+                "expected:\n"
+                "(OrmObj: 3,)\n"
+                "\n"
+                "actual:\n"
+                "(OrmObj: 2,)\n"
+                '\n'
+                'While comparing [1]: OrmObj not as expected:\n'
+                '\n'
+                'attributes differ:\n'
+                "'a': 3 (expected) != 2 (actual)"
+            ),
+            expected=[self.OrmObj(1), self.OrmObj(3)],
+            actual=query_set(),
+            ignore_eq=[self.OrmObj]
+        )
+
+    def test_ignore_eq_default_respects_broken_eq(self):
+        compare(self.OrmObj(1), self.OrmObj(2))
+
+    def test_ignore_eq_registered_by_type(self):
+        mock = type(_registry.ignore_eq_types)()
+        with Replace(_registry.ignore_eq_types, mock, container=_registry, name='ignore_eq_types'):
+            register(self.OrmObj, ignore_eq=True)
+            self.check_raises(
+                message=(
+                    'OrmObj not as expected:\n'
+                    '\n'
+                    'attributes differ:\n'
+                    "'a': 1 (expected) != 2 (actual)"
+                ),
+                expected=self.OrmObj(1),
+                actual=self.OrmObj(2),
+            )
+
+    def test_ignore_eq_mro_matching(self):
+        class SubOrm(self.OrmObj):
+            pass
+
+        self.check_raises(
+            message=(
+                'SubOrm not as expected:\n'
+                '\n'
+                'attributes differ:\n'
+                "'a': 1 (expected) != 2 (actual)"
+            ),
+            expected=SubOrm(1),
+            actual=SubOrm(2),
+            ignore_eq=self.OrmObj,
+        )
+
+    def test_ignore_eq_blocks_shortcut_for_nested_ignored_types(self):
+        # When any per-type ignore is in play, the `x == y` shortcut is
+        # disabled even at the container level — otherwise a list of
+        # OrmObj would have list.__eq__ silently delegate to OrmObj's
+        # broken __eq__ and report equal.
+        self.check_raises(
+            message=(
+                "sequence not as expected:\n"
+                "\n"
+                "same:\n"
+                "[OrmObj: 1]\n"
+                "\n"
+                "expected:\n"
+                "[OrmObj: 3]\n"
+                "\n"
+                "actual:\n"
+                "[OrmObj: 2]\n"
+                '\n'
+                'While comparing [1]: OrmObj not as expected:\n'
+                '\n'
+                'attributes differ:\n'
+                "'a': 3 (expected) != 2 (actual)"
+            ),
+            expected=[self.OrmObj(1), self.OrmObj(3)],
+            actual=[self.OrmObj(1), self.OrmObj(2)],
+            ignore_eq=self.OrmObj,
+        )
+
+    @dataclass(kw_only=True)
+    class Attrs:
+        x: int
+        y: int
+
+        def __repr__(self):
+            return f'{type(self).__name__}(x={self.x}, y={self.y})'
+
+    class OnlyXEq(Attrs):
+        def __eq__(self, other):
+            return self.x == other.x
+
+    class OnlyYEq(Attrs):
+        def __eq__(self, other):
+            return self.y == other.y
+
+    def test_ignore_eq_does_not_disable_other_types_eq(self):
+        # The OnlyYEq does not have its __eq__ ignored, so even though the instances have
+        # differing x attributes, no AssertionError is raised:
+        compare(
+            expected=self.OnlyYEq(x=1, y=3),
+            actual=self.OnlyYEq(x=2, y=3),
+            ignore_eq=self.OnlyXEq,
+        )
+        # The OnlyXEq instances are identical, so the ignore_eq doesn't uncover any attribute
+        # differences that would have been ignored:
+        compare(
+            expected=self.OnlyXEq(x=3, y=1),
+            actual=self.OnlyXEq(x=3, y=1),
+            ignore_eq=self.OnlyXEq,
+        )
+        # Now, we ignore the __eq__ of OnlyXEq, so an AssertionError is raised as the differences
+        # in the y attributes are no longer ignoreed:
+        self.check_raises(
+            message=(
+                "OnlyXEq not as expected:\n\n"
+                "attributes same:\n"
+                "['x']\n\n"
+                "attributes differ:\n"
+                "'y': 1 (expected) != 2 (actual)"
+            ),
+            expected=self.OnlyXEq(x=1, y=1),
+            actual=self.OnlyXEq(x=1, y=2),
+            ignore_eq=self.OnlyXEq,
+        )
+
+    def test_ignore_eq_does_not_disable_other_types_eq_in_sequence(self):
+        self.check_raises(
+            message=(
+                'sequence not as expected:\n\n'
+                'same:\n'
+                '[OnlyXEq(x=1, y=1)]\n\n'
+                'expected:\n'
+                '[OnlyYEq(x=1, y=3)]\n\n'
+                'actual:\n'
+                '[OnlyYEq(x=2, y=3)]\n\n'
+                'While comparing [1]: OnlyYEq not as expected:\n\n'
+                'attributes same:\n'
+                "['y']\n\n"
+                'attributes differ:\n'
+                "'x': 1 (expected) != 2 (actual)"
+            ),
+            # Here, we don't ignore_eq for OnlyXEq, so the two instances compare equal
+            # even though their y attributes differ. We ignore_eq for OnlyYEq, so even though the
+            # two OnlyYEq instances have identical y attributes, we ignore the __eq__ and so we
+            # get an AssertionError for the different in the x attributes.
+            expected=[self.OnlyXEq(x=1, y=1), self.OnlyYEq(x=1, y=3)],
+            actual=[self.OnlyXEq(x=1, y=2), self.OnlyYEq(x=2, y=3)],
+            ignore_eq=self.OnlyYEq,
+        )
+
+    def test_ignore_eq_registry_and_parameter_combine(self):
+
+        class OtherBroken:
+            def __init__(self, a):
+                self.a = a
+            def __eq__(self, other):
+                return True
+            def __repr__(self):
+                return 'OtherBroken: '+str(self.a)
+
+        register(self.OrmObj, ignore_eq=True)
+        try:
+            self.check_raises(
+                message=(
+                    'OtherBroken not as expected:\n'
+                    '\n'
+                    'attributes differ:\n'
+                    "'a': 1 (expected) != 2 (actual)"
+                ),
+                expected=OtherBroken(1),
+                actual=OtherBroken(2),
+                ignore_eq=OtherBroken,
+            )
+            self.check_raises(
+                message=(
+                    'OrmObj not as expected:\n'
+                    '\n'
+                    'attributes differ:\n'
+                    "'a': 1 (expected) != 2 (actual)"
+                ),
+                expected=self.OrmObj(1),
+                actual=self.OrmObj(2),
+                ignore_eq=OtherBroken,
+            )
+        finally:
+            _registry.ignore_eq_types.discard(self.OrmObj)
+
+    def test_register_requires_comparer_or_ignore_eq(self):
+        class SomeType:
+            pass
+
+        with ShouldRaise(TypeError(
+            "register() requires either a comparer or ignore_eq=True"
+        )):
+            register(SomeType)
+
+    def test_ignore_eq_per_type_with_shared_instance(self):
+        # When the same object appears at the same position in expected and
+        # actual, AlreadySeen kicks in on the second sighting. Equality must
+        # fall back to identity rather than the type's __eq__ — which is
+        # precisely the operator ignore_eq is asking us to distrust, and
+        # which may not cooperate with unknown operands like AlreadySeen.
+        class Strict:
+            def __init__(self, value):
+                self.value = value
+            def __eq__(self, other):
+                return isinstance(other, Strict) and self.value == other.value
+            def __hash__(self):
+                return hash(self.value)
+
+        s = Strict(1)
+        compare(expected=[s], actual=[s], ignore_eq=Strict)
+
+    def test_ignore_eq_registered_with_shared_instance(self):
+        # Same as above but via the registry — guards against a globally
+        # registered ignore_eq type leaking into unrelated comparisons that
+        # happen to reuse instances within a container.
+        class Strict:
+            def __init__(self, value):
+                self.value = value
+            def __eq__(self, other):
+                return isinstance(other, Strict) and self.value == other.value
+            def __hash__(self):
+                return hash(self.value)
+
+        with registry():
+            register(Strict, ignore_eq=True)
+            s = Strict(1)
+            compare(expected=[s], actual=[s])
 
     def test_django_orm_is_horrible_part_2(self):
 

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -31,7 +31,7 @@ from testfixtures.comparers import (
     compare_text,
     merge_ignored_attributes,
 )
-from testfixtures.comparison import Registry, _registry, like, register
+from testfixtures.comparison import Registry, _registry, like, register, registry
 from testfixtures.compat import PY_312_PLUS
 from testfixtures.mock import Mock, call
 from testfixtures.shouldraise import ShouldAssert
@@ -976,9 +976,7 @@ b
         def compare_my_object(x, y, context):
             return '%s != %s' % (x.name, y.name)
 
-        with Replacer() as r:
-            registry = Registry.initial({list: compare_sequence, str: compare_text})
-            r.replace('testfixtures.comparison._registry', registry)
+        with registry({list: compare_sequence, str: compare_text}):
             self.check_raises(
                 [1, MyObject('foo')], [1, MyObject('bar')],
                 "sequence not as expected:\n"
@@ -1629,6 +1627,7 @@ b
 
     def test_ignore_eq_registered_by_type(self):
         mock = type(_registry.ignore_eq_types)()
+        # Should have an empty registry primitive?
         with Replace(_registry.ignore_eq_types, mock, container=_registry, name='ignore_eq_types'):
             register(self.OrmObj, ignore_eq=True)
             self.check_raises(
@@ -1767,8 +1766,9 @@ b
             def __repr__(self):
                 return 'OtherBroken: '+str(self.a)
 
-        register(self.OrmObj, ignore_eq=True)
-        try:
+        with registry():
+            register(self.OrmObj, ignore_eq=True)
+            # use empty registry primitive
             self.check_raises(
                 message=(
                     'OtherBroken not as expected:\n'
@@ -1791,8 +1791,6 @@ b
                 actual=self.OrmObj(2),
                 ignore_eq=OtherBroken,
             )
-        finally:
-            _registry.ignore_eq_types.discard(self.OrmObj)
 
     def test_register_requires_comparer_or_ignore_eq(self):
         class SomeType:

--- a/tests/test_django/test_compare.py
+++ b/tests/test_django/test_compare.py
@@ -3,23 +3,22 @@ from unittest import TestCase
 import pytest
 from django.contrib.auth.models import User
 from testfixtures import OutputCapture, Replacer
+from testfixtures.comparison import registry
 from .models import SampleModel
 from tests.test_django.manage import main
 
 from tests.test_compare import CompareHelper
 from testfixtures import compare
-from testfixtures.django import compare as django_compare
 
 
 class CompareTests(CompareHelper, TestCase):
 
     def test_simple_same(self):
-        django_compare(SampleModel(id=1), SampleModel(id=1))
+        compare(SampleModel(id=1), SampleModel(id=1))
 
     def test_simple_diff(self):
         self.check_raises(
             SampleModel(id=1), SampleModel(id=2),
-            compare=django_compare,
             message=(
                 'SampleModel not as expected:\n'
                 '\n'
@@ -32,16 +31,14 @@ class CompareTests(CompareHelper, TestCase):
         )
 
     def test_simple_ignore_fields(self):
-        django_compare(SampleModel(id=1), SampleModel(id=1),
-                       ignore_fields=['id'])
+        compare(SampleModel(id=1), SampleModel(id=1), ignore_fields=['id'])
 
     def test_ignored_because_speshul(self):
-        django_compare(SampleModel(not_editable=1), SampleModel(not_editable=2))
+        compare(SampleModel(not_editable=1), SampleModel(not_editable=2))
 
     def test_ignored_because_no_longer_speshul(self):
         self.check_raises(
             SampleModel(not_editable=1), SampleModel(not_editable=2),
-            compare=django_compare,
             message=(
                 'SampleModel not as expected:\n'
                 '\n'
@@ -55,13 +52,13 @@ class CompareTests(CompareHelper, TestCase):
         )
 
     def test_normal_compare_id_same(self):
-        # other diffs ignored
-        compare(SampleModel(id=1, value=1), SampleModel(id=1, value=2))
+        # without the comparer registered, the models compare equal:
+        with registry():
+            compare(SampleModel(id=1, value=1), SampleModel(id=1, value=2))
 
     def test_normal_compare_id_diff(self):
         self.check_raises(
             SampleModel(id=3, value=1), SampleModel(id=4, value=2),
-            compare=django_compare,
             message=(
                 'SampleModel not as expected:\n'
                 '\n'
@@ -82,9 +79,9 @@ class CompareTests(CompareHelper, TestCase):
     @pytest.mark.django_db
     def test_many_to_many_same(self):
         user = User.objects.create(username='foo')
-        django_compare(user,
-                       expected=User(
-                           username='foo', first_name='', last_name='',
-                           is_superuser=False
-                       ),
-                       ignore_fields=['id', 'date_joined'])
+        compare(user,
+                expected=User(
+                    username='foo', first_name='', last_name='',
+                    is_superuser=False
+                ),
+                ignore_fields=['id', 'date_joined'])


### PR DESCRIPTION
Centred on per-type `ignore_eq`, with a handful of related docs and internals cleanups picked up along the way.

## Highlights

- **Per-type `ignore_eq`** — `compare(..., ignore_eq=SomeType)` (or an iterable of types, or `True` for everything) now skips `__eq__` only for instances of the given types, instead of the previous all-or-nothing flag. Standard containers (`list`, `tuple`, `dict`, `set`, `frozenset`) automatically have their `__eq__` bypassed when they may contain an ignored type; custom containers can opt in by being passed alongside.
- **Type registry** — new `register()` for globally registering per-type comparison behaviour (currently `ignore_eq`), plus `Registry.install()` / `uninstall()` and a `registry()` context manager so tests can scope registrations.
- **`compare_django` removed** — Django model comparison now goes through the standard `compare()` path using the new per-type machinery, dropping a chunk of bespoke code.

## Docs

- Documented `AlreadySeen` and the `CompareContext` methods available to custom comparers.
- Sphinx now shows type hints in both signature and description.

## Internals

- `UNSAFE_ITERABLES` brought in line with the other module-level constants.
- `collections.abc.Iterable` used for annotations now that it's supported.
- `__all__` added to `comparers` so `from testfixtures.comparers import *` doesn't leak typing imports.