### PR TITLE
Fix tests with Python 3.15

### DIFF
--- a/tests/test_shouldwarn.py
+++ b/tests/test_shouldwarn.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 
+import sys
 import warnings
 
 from testfixtures import (
@@ -147,6 +148,8 @@ class ShouldWarnTests(TestCase):
             message=C(DeprecationWarning('foo')),
             source=None
         )
+        if sys.version_info >= (3, 15):
+            expected_attrs['module']='bar_module'
 
         compare(expected=C(warnings.WarningMessage, **expected_attrs),
             actual=recorded[0])


### PR DESCRIPTION
See-Also: https://github.com/python/cpython/pull/149298

Python 3.15 hasn't been released yet so there is no hurry.

```
==================================================== FAILURES ====================================================
______________________________________ ShouldWarnTests.test_maximal_explore ______________________________________

self = <tests.test_shouldwarn.ShouldWarnTests testMethod=test_maximal_explore>

    def test_maximal_explore(self):
        with ShouldWarn() as recorded:
            warnings.warn_explicit(
                'foo', DeprecationWarning, 'bar.py', 42, 'bar_module'
            )
        compare(len(recorded), expected=1)
    
        expected_attrs = dict(
            _category_name='DeprecationWarning',
            category=DeprecationWarning,
            file=None,
            filename='bar.py',
            line=None,
            lineno=42,
            message=C(DeprecationWarning('foo')),
            source=None
        )
    
>       compare(expected=C(warnings.WarningMessage, **expected_attrs),
            actual=recorded[0])
E       AssertionError: not equal:
E       
E       <C:_py_warnings.WarningMessage(failed)>
E       attributes same:
E       ['_category_name', 'category', 'file', 'filename', 'line', 'lineno', 'message', 'source']
E       
E       attributes in actual but not Comparison:
E       'module': 'bar_module'
E       </C:_py_warnings.WarningMessage> (expected)
E       <WarningMessage {message : DeprecationWarning('foo'), category : 'DeprecationWarning', module : 'bar_module', filename : 'bar.py', lineno : 42, line : None}> (actual)

expected_attrs = {'_category_name': 'DeprecationWarning',
 'category': <class 'DeprecationWarning'>,
 'file': None,
 'filename': 'bar.py',
 'line': None,
 'lineno': 42,
 'message': <C:builtins.DeprecationWarning>args: ('foo',)</>,
 'source': None}
recorded   = [<WarningMessage {message : DeprecationWarning('foo'), category : 'DeprecationWarning', module : 'bar_module', filename : 'bar.py', lineno : 42, line : None}>]
self       = <tests.test_shouldwarn.ShouldWarnTests testMethod=test_maximal_explore>

tests/test_shouldwarn.py:151: AssertionError

```

```
$ python3.15 --version
Python 3.15.0b3
```