### PR TITLE
Add Python 3.15 (beta) to CI alongside 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
         python-version:
           - "3.11"
           - "3.14"
+          - "3.15"
         uv-resolution:
           - "lowest-direct"
           - "highest"
@@ -81,6 +82,7 @@ jobs:
         python-version:
           - "3.11"
           - "3.14"
+          - "3.15"
     steps:
       - uses: cjw296/python-action/check-typing@v3
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,10 @@ polars = ["polars>=1.32"]
 pandas = ["pandas>=2.3.3"]
 numpy = ["numpy>=2.3.2"]
 structlog = ["structlog>=24.3.0"]
-pydantic = ["pydantic>=2.12.0"]
+pydantic = [
+    "pydantic>=2.12.0; python_version < '3.15'",
+    "pydantic>=2.13.0; python_version >= '3.15'",
+]
 twisted = ["twisted>=22.1"]
 yaml = ["pyyaml>=6.0.3"]
 toml = ["tomlkit>=0.10.0"]

--- a/src/testfixtures/compat.py
+++ b/src/testfixtures/compat.py
@@ -6,6 +6,7 @@ PY_VERSION: Tuple[int, int] = sys.version_info[:2]
 
 PY_312_PLUS: bool = PY_VERSION >= (3, 12)
 PY_313_PLUS: bool = PY_VERSION >= (3, 13)
+PY_315_PLUS: bool = PY_VERSION >= (3, 15)
 
 if PY_313_PLUS:
     from typing import TypeVar as TypeVar

--- a/tests/test_shouldwarn.py
+++ b/tests/test_shouldwarn.py
@@ -6,6 +6,7 @@ from testfixtures import (
     ShouldWarn, compare, ShouldRaise, ShouldNotWarn,
     Comparison as C
 )
+from testfixtures.compat import PY_315_PLUS
 from testfixtures.shouldraise import ShouldAssert
 
 
@@ -147,6 +148,8 @@ class ShouldWarnTests(TestCase):
             message=C(DeprecationWarning('foo')),
             source=None
         )
+        if PY_315_PLUS:
+            expected_attrs['module'] = 'bar_module'
 
         compare(expected=C(warnings.WarningMessage, **expected_attrs),
             actual=recorded[0])


### PR DESCRIPTION
WarningMessage gained a module attribute in 3.15; account for it in the ShouldWarn explore test.